### PR TITLE
Add CloudLinux support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class icinga2::params {
   # Icinga 2 common package parameters
   case $::operatingsystem {
     #CentOS systems:
-    'CentOS': {
+    'CentOS', 'CloudLinux': {
       #Pick the right package provider:
       $package_provider = 'yum'
     }
@@ -58,7 +58,7 @@ class icinga2::params {
   #Pick the right package parameters based on the OS:
   case $::operatingsystem {
     #CentOS systems:
-    'CentOS': {
+    'CentOS', 'CloudLinux': {
       case $::operatingsystemmajrelease {
         '6': {
           #Icinga 2 server package
@@ -106,7 +106,7 @@ class icinga2::params {
 
   case $::operatingsystem {
     #CentOS systems:
-    'CentOS': {
+    'CentOS', 'CloudLinux': {
       #Settings for /etc/icinga2/:
       $etc_icinga2_owner = 'icinga'
       $etc_icinga2_group = 'icinga'
@@ -254,7 +254,7 @@ class icinga2::params {
 
   case $::operatingsystem {
     #Icinga 2 server daemon names for Red Had/CentOS systems:
-    'CentOS': {
+    'CentOS', 'CloudLinux': {
       case $::operatingsystemmajrelease {
         '6': {
           $icinga2_server_service_name = 'icinga2'
@@ -303,7 +303,7 @@ class icinga2::params {
 
   case $::operatingsystem {
     #File and template variable names for Red Had/CentOS systems:
-    'CentOS': {
+    'CentOS', 'CloudLinux': {
       $nrpe_config_basedir = "/etc/nagios"
       $nrpe_plugin_libdir  = "/usr/lib64/nagios/plugins"
       $nrpe_pid_file_path  = "/var/run/nrpe/nrpe.pid"
@@ -326,7 +326,7 @@ class icinga2::params {
   # Icinga 2 client package parameters
   case $::operatingsystem {
     #CentOS systems:
-    'CentOS': {
+    'CentOS', 'CloudLinux': {
       case $::operatingsystemmajrelease {
         '6': {
           #Pick the right list of client packages:
@@ -370,7 +370,7 @@ class icinga2::params {
   # Icinga 2 client service parameters
   case $::operatingsystem {
     #Daemon names for Red Had/CentOS systems:
-    'CentOS': {
+    'CentOS', 'CloudLinux': {
       $nrpe_daemon_name = 'nrpe'
     }
 


### PR DESCRIPTION
CloudLinux is a similar derivative of RHEL based on CentOS which provides a few extra features.  This adds support to it to allow installation.
