### PR TITLE
fix for json syntax error

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemmajrelease": [
-        "7",
+        "7"
       ]
     },
     {


### PR DESCRIPTION
## This syntax error is breaking puppet in my setup.

err: /File[/var/lib/puppet/lib]: Failed to generate additional resources using 'eval_generate: Error 400 on SERVER: expected next element in array at '
    },
    {
      '!
err: /File[/var/lib/puppet/lib]: Could not evaluate: Error 400 on SERVER: expected next element in array at '
    },
    {
      '! Could not retrieve file metadata for puppet://foo.acme.org/plugins: Error 400 on SERVER: expected next element in array at '
    },
    {
      '!
