### PR TITLE
Allow NRPE command argument processing  

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,18 @@ class { 'icinga2::nrpe':
 }
 </pre>
 
+By default the NRPE daemon will not allow clients to specify arguments to the commands that are executed.  To enable NRPE to allow client argument processing you can call the icinga2::nrpe class with the **allow_command_argument_processing** parameter.
+
+Valid parameter values are: 0=do not allow arguments, 1=allow command arguments
+
+**WARNING! - ENABLING THIS OPTION IS A SECURITY RISK!**
+
+````
+class { 'icinga2::nrpe':
+  allow_command_argument_processing => 1,
+}
+````
+
 **Note:** If you would like to install NRPE on a node that also has the `icinga2::server` class applied, be sure to set the `$server_install_nagios_plugins` parameter in your call to `icinga2::server` to `false`:
 
 <pre>

--- a/manifests/nrpe.pp
+++ b/manifests/nrpe.pp
@@ -6,12 +6,13 @@
 
 class icinga2::nrpe (
 
-  $nrpe_listen_port        = $icinga2::params::nrpe_listen_port,
-  $nrpe_debug_level        = $icinga2::params::nrpe_debug_level,
-  $nrpe_log_facility       = $icinga2::params::nrpe_log_facility,
-  $nrpe_command_timeout    = $icinga2::params::nrpe_command_timeout,
-  $nrpe_connection_timeout = $icinga2::params::nrpe_connection_timeout,
-  $nrpe_allowed_hosts      = $icinga2::params::nrpe_allowed_hosts
+  $nrpe_listen_port                       = $icinga2::params::nrpe_listen_port,
+  $nrpe_debug_level                       = $icinga2::params::nrpe_debug_level,
+  $nrpe_log_facility                      = $icinga2::params::nrpe_log_facility,
+  $nrpe_command_timeout                   = $icinga2::params::nrpe_command_timeout,
+  $nrpe_connection_timeout                = $icinga2::params::nrpe_connection_timeout,
+  $nrpe_allowed_hosts                     = $icinga2::params::nrpe_allowed_hosts,
+  $nrpe_allow_command_argument_processing = $icinga2::params::allow_command_argument_processing,
 
 ) inherits icinga2::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -287,6 +287,10 @@ class icinga2::params {
   $nrpe_connection_timeout = '300'
   #Note: because we use .join in the nrpe.cfg.erb template, this value *must* be an array
   $nrpe_allowed_hosts      = ['127.0.0.1',]
+  #Dtermines whether or not the NRPE daemon will allow clients to specify arguments to commands that are executed
+  # *** ENABLING THIS OPTION IS A SECURITY RISK! ***
+  # Defaults to NOT allow command arguments
+  $allow_command_argument_processing = '0'
 
   case $::operatingsystem {
     #File and template variable names for Red Had/CentOS systems:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -287,7 +287,7 @@ class icinga2::params {
   $nrpe_connection_timeout = '300'
   #Note: because we use .join in the nrpe.cfg.erb template, this value *must* be an array
   $nrpe_allowed_hosts      = ['127.0.0.1',]
-  #Dtermines whether or not the NRPE daemon will allow clients to specify arguments to commands that are executed
+  #Determines whether or not the NRPE daemon will allow clients to specify arguments to commands that are executed
   # *** ENABLING THIS OPTION IS A SECURITY RISK! ***
   # Defaults to NOT allow command arguments
   $allow_command_argument_processing = '0'

--- a/templates/nrpe.cfg.erb
+++ b/templates/nrpe.cfg.erb
@@ -108,7 +108,7 @@ allowed_hosts=<%= scope.lookupvar('icinga2::nrpe::nrpe_allowed_hosts').join(',')
 #
 # Values: 0=do not allow arguments, 1=allow command arguments
 
-dont_blame_nrpe=0
+dont_blame_nrpe=<%= scope.lookupvar('icinga2::nrpe::allow_command_argument_processing') %>
 
 
 

--- a/templates/nrpe.cfg.erb
+++ b/templates/nrpe.cfg.erb
@@ -108,7 +108,7 @@ allowed_hosts=<%= scope.lookupvar('icinga2::nrpe::nrpe_allowed_hosts').join(',')
 #
 # Values: 0=do not allow arguments, 1=allow command arguments
 
-dont_blame_nrpe=<%= scope.lookupvar('icinga2::nrpe::allow_command_argument_processing') %>
+dont_blame_nrpe=<%= scope.lookupvar('icinga2::nrpe::nrpe_allow_command_argument_processing') %>
 
 
 


### PR DESCRIPTION
Moved this to a feature branch to do PR from...

Adds a parameter to icinga2::nrpe class nrpe_allow_command_argument_processing to allow clients to specify arguemnts to the command line.

By default this is set to 0 ( do not allow arguments) in params.pp

Includes updated README section 
