### PR TITLE
Add independent check plugin defined type

### DIFF
--- a/manifests/checkplugin.pp
+++ b/manifests/checkplugin.pp
@@ -9,7 +9,7 @@ define icinga2::checkplugin (
   $checkplugin_target_file_owner  = 'root',
   $checkplugin_target_file_group  = 'root',
   $checkplugin_target_file_mode   = '0755',
-  $checkplugin_source_file        = undef,
+  $checkplugin_template           = undef,
 ) {
 
   #Do some validation of the class' parameters:
@@ -24,7 +24,7 @@ define icinga2::checkplugin (
     owner   => $checkplugin_target_file_owner,
     group   => $checkplugin_target_file_group,
     mode    => $checkplugin_target_file_mode,
-    source  => $checkplugin_source_file,
+    content => template("icinga2/${checkplugin_template}"),
     require => Package[$icinga2::params::icinga2_client_packages],
   }
 

--- a/manifests/checkplugin.pp
+++ b/manifests/checkplugin.pp
@@ -1,0 +1,31 @@
+# == Defined Type: icinga2::checkplugin
+#
+# === Parameters
+#
+#
+define icinga2::checkplugin (
+  $checkplugin_name               = $name,
+  $checkplugin_libdir             = $icinga2::params::checkplugin_libdir,
+  $checkplugin_target_file_owner  = 'root',
+  $checkplugin_target_file_group  = 'root',
+  $checkplugin_target_file_mode   = '0755',
+  $checkplugin_source_file        = undef,
+) {
+
+  #Do some validation of the class' parameters:
+  validate_string($name)
+  validate_string($checkplugin_libdir)
+  validate_string($checkplugin_name)
+  validate_string($checkplugin_target_file_owner)
+  validate_string($checkplugin_target_file_group)
+  validate_string($checkplugin_target_file_mode)
+
+  file { "${checkplugin_libdir}/${checkplugin_name}":
+    owner   => $checkplugin_target_file_owner,
+    group   => $checkplugin_target_file_group,
+    mode    => $checkplugin_target_file_mode,
+    source  => $checkplugin_source_file,
+    require => Package[$icinga2::params::icinga2_client_packages],
+  }
+
+}

--- a/manifests/checkplugin.pp
+++ b/manifests/checkplugin.pp
@@ -4,12 +4,14 @@
 #
 #
 define icinga2::checkplugin (
-  $checkplugin_name               = $name,
-  $checkplugin_libdir             = $icinga2::params::checkplugin_libdir,
-  $checkplugin_target_file_owner  = 'root',
-  $checkplugin_target_file_group  = 'root',
-  $checkplugin_target_file_mode   = '0755',
-  $checkplugin_template           = undef,
+  $checkplugin_name                     = $name,
+  $checkplugin_libdir                   = $icinga2::params::checkplugin_libdir,
+  $checkplugin_target_file_owner        = 'root',
+  $checkplugin_target_file_group        = 'root',
+  $checkplugin_target_file_mode         = '0755',
+  $checkplugin_file_distribution_method = 'content',
+  $checkplugin_template                 = undef,
+  $checkplugin_source_file              = undef,
 ) {
 
   #Do some validation of the class' parameters:
@@ -20,12 +22,28 @@ define icinga2::checkplugin (
   validate_string($checkplugin_target_file_group)
   validate_string($checkplugin_target_file_mode)
 
-  file { "${checkplugin_libdir}/${checkplugin_name}":
-    owner   => $checkplugin_target_file_owner,
-    group   => $checkplugin_target_file_group,
-    mode    => $checkplugin_target_file_mode,
-    content => template("icinga2/${checkplugin_template}"),
-    require => Package[$icinga2::params::icinga2_client_packages],
+  if $checkplugin_file_distribution_method == 'content' {
+    file { "${checkplugin_libdir}/${checkplugin_name}":
+      owner   => $checkplugin_target_file_owner,
+      group   => $checkplugin_target_file_group,
+      mode    => $checkplugin_target_file_mode,
+      content => template("icinga2/${checkplugin_template}"),
+      require => Package[$icinga2::params::icinga2_client_packages],
+    }
+  }
+  elsif $checkplugin_file_distribution_method == 'source' {
+    file { "${checkplugin_libdir}/${checkplugin_name}":
+      owner   => $checkplugin_target_file_owner,
+      group   => $checkplugin_target_file_group,
+      mode    => $checkplugin_target_file_mode,
+      source  => $checkplugin_source_file,
+      require => Package[$icinga2::params::icinga2_client_packages],
+    }
+  }
+  else {
+    notify {'Missing/Incorrect File Distribution Method':
+      message => 'The parameter checkplugin_file_distribution_method is missing or incorrect. Please set content or source',
+    }
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -297,7 +297,7 @@ class icinga2::params {
     'CentOS': {
       $nrpe_config_basedir = '/etc/nagios'
       $nrpe_plugin_libdir  = '/usr/lib64/nagios/plugins'
-      $checkplugin_libdir   = '/usr/lib/nagios/plugins'
+      $checkplugin_libdir  = '/usr/lib64/nagios/plugins'
       $nrpe_pid_file_path  = '/var/run/nrpe/nrpe.pid'
       $nrpe_user           = 'nrpe'
       $nrpe_group          = 'nrpe'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -297,6 +297,7 @@ class icinga2::params {
     'CentOS': {
       $nrpe_config_basedir = '/etc/nagios'
       $nrpe_plugin_libdir  = '/usr/lib64/nagios/plugins'
+      $checkplugin_libdir   = '/usr/lib/nagios/plugins'
       $nrpe_pid_file_path  = '/var/run/nrpe/nrpe.pid'
       $nrpe_user           = 'nrpe'
       $nrpe_group          = 'nrpe'
@@ -305,6 +306,7 @@ class icinga2::params {
     'Ubuntu': {
       $nrpe_config_basedir  = '/etc/nagios'
       $nrpe_plugin_libdir   = '/usr/lib/nagios/plugins'
+      $checkplugin_libdir   = '/usr/lib/nagios/plugins'
       $nrpe_pid_file_path   = '/var/run/nagios/nrpe.pid'
       $nrpe_user            = 'nagios'
       $nrpe_group           = 'nagios'
@@ -313,6 +315,7 @@ class icinga2::params {
     'Debian': {
       $nrpe_config_basedir  = '/etc/nagios'
       $nrpe_plugin_libdir   = '/usr/lib/nagios/plugins'
+      $checkplugin_libdir   = '/usr/lib/nagios/plugins'
       $nrpe_pid_file_path   = '/var/run/nagios/nrpe.pid'
       $nrpe_user            = 'nagios'
       $nrpe_group           = 'nagios'


### PR DESCRIPTION
This defined type is independent of NRPE to make it less confusing when using other client that reference the check plugins (scripts) or check plugins (scripts) that are not used via NRPE but executed locally from the Icinga 2 Core node.

Created a new parameter $checkplugin_libdir   = '/usr/lib/nagios/plugins' to keep backwards compatibility with the nrpe::plugins manifest.
