### PR TITLE
Fix default host object address for systemd's predictable interfaces

### DIFF
--- a/manifests/object/host.pp
+++ b/manifests/object/host.pp
@@ -12,7 +12,7 @@
 define icinga2::object::host (
   $object_hostname = $name,
   $display_name = $fqdn,
-  $ipv4_address = $ipaddress_eth0,
+  $ipv4_address = $ipaddress,
   $ipv6_address = undef,
   $template_to_import = 'generic-host',
   $groups = [],


### PR DESCRIPTION
Due to Systemd's predictable interface naming there is no longer an eth0 available.
Lucky for us Facter picks the interface containing the default route as default value for $ipaddress.

Furthermore $ipaddress_eth0 isn't cross platform. We should leave things like this up to Facter.

```
# ifconfig
eno16777728: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 172.16.0.1  netmask 255.255.0.0  broadcast 172.16.255.255
        ether 00:0c:29:dd:1f:cf  txqueuelen 1000  (Ethernet)
        RX packets 3776862  bytes 4759642379 (4.4 GiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 1300573  bytes 165057612 (157.4 MiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```

```
# facter | grep -i ipaddress
ipaddress => 172.16.0.1
ipaddress_eno16777728 => 172.16.0.1
```
