### PR TITLE
Add inline checkplugin file distribution method

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,23 @@ icinga2::checkplugin { 'check_diskstats':
 }
 ````
 
+Example 3: Distribute check plugin in a manifest
+```
+icinga2::checkplugin { 'check_diskstats':
+  checkplugin_file_distribution_method => 'inline'
+  checkplugin_source_inline            => 'command[check_disks]=/usr/lib64/nagios/plugins/check_disk -w 20 -c 10 -p /'
+}
+```
+
+Example 4: Distribute check plugin stored in Hiera(-yaml)
+```
+---
+icinga2::checkplugin:
+  check_diskstats:
+    checkplugin_file_distribution_method: 'inline'
+    checkplugin_source_inline:            'command[check_disks]=/usr/lib64/nagios/plugins/check_disk -w 20 -c 10 -p /'
+```
+
 ###[Object type usage](id:object_type_usage)
 
 This module includes several defined types that can be used to automatically generate Icinga 2 format object definitions. They function in a similar way to [the built-in Nagios types that are included in Puppet](http://docs.puppetlabs.com/guides/exported_resources.html#exported-resources-with-nagios).

--- a/manifests/checkplugin.pp
+++ b/manifests/checkplugin.pp
@@ -13,6 +13,7 @@ define icinga2::checkplugin (
   $checkplugin_template_module          = 'icinga2',
   $checkplugin_template                 = undef,
   $checkplugin_source_file              = undef,
+  $checkplugin_source_inline            = undef,
 ) {
 
   #Do some validation of the class' parameters:
@@ -38,6 +39,15 @@ define icinga2::checkplugin (
       group   => $checkplugin_target_file_group,
       mode    => $checkplugin_target_file_mode,
       source  => $checkplugin_source_file,
+      require => Package[$icinga2::params::icinga2_client_packages],
+    }
+  }
+  elsif $checkplugin_file_distribution_method == 'inline' {
+    file { "${checkplugin_libdir}/${checkplugin_name}":
+      owner   => $checkplugin_target_file_owner,
+      group   => $checkplugin_target_file_group,
+      mode    => $checkplugin_target_file_mode,
+      content => $checkplugin_source_inline,
       require => Package[$icinga2::params::icinga2_client_packages],
     }
   }


### PR DESCRIPTION
With this patch we can specify the content of `${checkplugin_libdir}/${checkplugin_name}` inline.

E.g.:

```
::icinga2::checkplugin { 'check_diskstats':
  checkplugin_file_distribution_method => 'inline'
  checkplugin_source_inline            => 'command[check_disks]=/usr/lib64/nagios/plugins/check_disk -w 20 -c 10 -p /'
}
```

Or in my case using hiera-yaml:

```

---
icinga2::checkplugin:
  check_diskstats:
    checkplugin_file_distribution_method: 'inline'
    checkplugin_source_inline:            'command[check_disks]=/usr/lib64/nagios/plugins/check_disk -w 20 -c 10 -p /'
```
