### PR TITLE
Checkcommand source inline

### DIFF
--- a/manifests/checkplugin.pp
+++ b/manifests/checkplugin.pp
@@ -13,6 +13,7 @@ define icinga2::checkplugin (
   $checkplugin_template_module          = 'icinga2',
   $checkplugin_template                 = undef,
   $checkplugin_source_file              = undef,
+  $checkplugin_source_inline            = undef,
 ) {
 
   #Do some validation of the class' parameters:
@@ -38,6 +39,15 @@ define icinga2::checkplugin (
       group   => $checkplugin_target_file_group,
       mode    => $checkplugin_target_file_mode,
       source  => $checkplugin_source_file,
+      require => Package[$icinga2::params::icinga2_client_packages],
+    }
+  }
+  elsif $checkplugin_file_distribution_method == 'inline' {
+    file { "${checkplugin_libdir}/${checkplugin_name}":
+      owner   => $checkplugin_target_file_owner,
+      group   => $checkplugin_target_file_group,
+      mode    => $checkplugin_target_file_mode,
+      content => $checkplugin_source_inline,
       require => Package[$icinga2::params::icinga2_client_packages],
     }
   }

--- a/manifests/object/checkcommand.pp
+++ b/manifests/object/checkcommand.pp
@@ -23,6 +23,7 @@ define icinga2::object::checkcommand (
   $checkcommand_template_module          = 'icinga2',
   $checkcommand_template                 = 'object_checkcommand.conf.erb',
   $checkcommand_source_file              = undef,
+  $checkcommand_source_inline            = undef,
   $checkcommand_file_distribution_method = 'content',
   $target_file_name                      = "${name}.conf",
   $target_file_ensure                    = file,
@@ -76,6 +77,16 @@ define icinga2::object::checkcommand (
         notify => Service['icinga2'],
       }
     }
+    elsif $checkcommand_file_distribution_method == 'inline' {
+      file {"${target_dir}/${target_file_name}":
+        ensure  => $target_file_ensure,
+        owner   => $target_file_owner,
+        group   => $target_file_group,
+        mode    => $target_file_mode,
+        content => $checkcommand_source_inline,
+        notify  => Service['icinga2'],
+      }
+    }
     else {
       notify {'Missing/Incorrect File Distribution Method':
         message => 'The parameter checkcommand_file_distribution_method is missing or incorrect. Please set content or source',
@@ -83,9 +94,9 @@ define icinga2::object::checkcommand (
     }
   }
 
-  #...otherwise, use the same file resource but without a notify => parameter: 
+  #...otherwise, use the same file resource but without a notify => parameter:
   else {
-  
+
     if $checkcommand_file_distribution_method == 'content' {
       file {"${target_dir}/${target_file_name}":
         ensure  => $target_file_ensure,
@@ -104,12 +115,21 @@ define icinga2::object::checkcommand (
         source => $checkcommand_source_file,
       }
     }
+    elsif $checkcommand_file_distribution_method == 'inline' {
+      file {"${target_dir}/${target_file_name}":
+        ensure  => $target_file_ensure,
+        owner   => $target_file_owner,
+        group   => $target_file_group,
+        mode    => $target_file_mode,
+        content => $checkcommand_source_inline,
+      }
+    }
     else {
       notify {'Missing/Incorrect File Distribution Method':
         message => 'The parameter checkcommand_file_distribution_method is missing or incorrect. Please set content or source',
       }
     }
-  
+
   }
 
 }


### PR DESCRIPTION
Similar to #77, this patch provides a way to provide content for `${target_dir}/${target_file_name}` inline.
