### PR TITLE
Add support for RedHat operatingsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ For Ubuntu systems, this module requires the [Puppet Labs apt module](https://gi
 
 On EL-based systems (CentOS, Red Hat Enterprise Linux, Fedora, etc.), the [EPEL package repository](https://fedoraproject.org/wiki/EPEL) is required. You can also use the [icinga2::nrpe class](#nrpe-usage) to set up NRPE on CentOS 5. It is discouraged to set up Icinga2 Server on this old of a distribution. You are encouraged to use at least CentOS 6 or higher.
 
+####Note for RedHat
+
+If you are using RedHat Satellite server, set
+<pre>
+   $manage_repos = false
+</pre>
+
+in [icinga2::server class] and make sure, you have a channel set up with the contents of the icinga2 repository and the needed packages from epel. If you leave it at true, the epel repository will be used directly.
+
 If you would like to use the `icinga2::object` defined types as [exported resources](https://docs.puppetlabs.com/guides/exported_resources.html), you'll need to have your Puppet master set up with PuppetDB. See the Puppet Labs documentation for more info: [Docs: PuppetDB](https://docs.puppetlabs.com/puppetdb/)
 
 ###Server requirements

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you are using RedHat Satellite server, set
    $manage_repos = false
 </pre>
 
-in [icinga2::server class] and make sure, you have a channel set up with the contents of the icinga2 repository and the needed packages from epel. If you leave it at true, the epel repository will be used directly.
+in `icinga2::server` class and make sure, you have a channel set up with the contents of the icinga2 repository and the needed packages from EPEL. If you leave it at true, the EPEL repository will be used directly.
 
 If you would like to use the `icinga2::object` defined types as [exported resources](https://docs.puppetlabs.com/guides/exported_resources.html), you'll need to have your Puppet master set up with PuppetDB. See the Puppet Labs documentation for more info: [Docs: PuppetDB](https://docs.puppetlabs.com/puppetdb/)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class icinga2::params {
   # Icinga 2 common package parameters
   case $::operatingsystem {
     #CentOS systems:
-    'CentOS': {
+    'CentOS', 'RedHat': {
       #Pick the right package provider:
       $package_provider = 'yum'
     }
@@ -70,7 +70,7 @@ class icinga2::params {
   #Pick the right package parameters based on the OS:
   case $::operatingsystem {
     #CentOS systems:
-    'CentOS': {
+    'CentOS', 'RedHat': {
       case $::operatingsystemmajrelease {
         '5': {
           #Icinga 2 server package
@@ -144,7 +144,7 @@ class icinga2::params {
 
   case $::operatingsystem {
     #CentOS systems:
-    'CentOS': {
+    'CentOS', 'RedHat': {
       #Settings for /etc/icinga2/:
       $etc_icinga2_owner = 'icinga'
       $etc_icinga2_group = 'icinga'
@@ -244,7 +244,7 @@ class icinga2::params {
 
   case $::operatingsystem {
     #Icinga 2 server daemon names for Red Had/CentOS systems:
-    'CentOS': {
+    'CentOS', 'RedHat': {
       case $::operatingsystemmajrelease {
         '5': {
           $icinga2_server_service_name = 'icinga2'
@@ -314,7 +314,7 @@ class icinga2::params {
 
   case $::operatingsystem {
     #File and template variable names for Red Had/CentOS systems:
-    'CentOS': {
+    'CentOS', 'RedHat': {
       $nrpe_config_basedir = '/etc/nagios'
       $nrpe_plugin_libdir  = '/usr/lib64/nagios/plugins'
       $checkplugin_libdir  = '/usr/lib64/nagios/plugins'
@@ -348,7 +348,7 @@ class icinga2::params {
   # Icinga 2 client package parameters
   case $::operatingsystem {
     #CentOS systems:
-    'CentOS': {
+    'CentOS', 'RedHat': {
       case $::operatingsystemmajrelease {
         '5': {
           #Pick the right list of client packages:
@@ -409,7 +409,7 @@ class icinga2::params {
   # Icinga 2 client service parameters
   case $::operatingsystem {
     #Daemon names for Red Had/CentOS systems:
-    'CentOS': {
+    'CentOS', 'RedHat': {
       $nrpe_daemon_name = 'nrpe'
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,12 @@ class icinga2::params {
       #Pick the right package provider:
       $package_provider = 'yum'
     }
+	
+	#RedHat systems:
+    'RedHat': {
+      #Pick the right package provider:
+      $package_provider = 'yum'
+    }
 
     #Ubuntu systems:
     'Ubuntu': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,11 +19,11 @@ class icinga2::params {
   # Icinga 2 common package parameters
   case $::operatingsystem {
     #CentOS or RedHat systems:
-    /(CentOS|RedHat)/': {
+    /(CentOS|RedHat)/: {
       #Pick the right package provider:
       $package_provider = 'yum'
     }
-	
+
     #Ubuntu systems:
     'Ubuntu': {
       #Pick the right package provider:
@@ -94,6 +94,7 @@ class icinga2::params {
         default: { fail("${::operatingsystemmajrelease} is not a supported CentOS release!") }
       }
     }
+
     #RedHat systems:
     'RedHat': {
       case $::operatingsystemmajrelease {
@@ -119,7 +120,6 @@ class icinga2::params {
         default: { fail("${::operatingsystemmajrelease} is not a supported RedHat release!") }
       }
     }
-
 
     #Ubuntu systems:
     'Ubuntu': {
@@ -348,6 +348,7 @@ class icinga2::params {
       $nrpe_user           = 'nrpe'
       $nrpe_group          = 'nrpe'
     }
+
     #File and template variable names for Ubuntu systems:
     'Ubuntu': {
       $nrpe_config_basedir  = '/etc/nagios'
@@ -357,6 +358,7 @@ class icinga2::params {
       $nrpe_user            = 'nagios'
       $nrpe_group           = 'nagios'
     }
+
     #File and template variable names for Ubuntu systems:
     'Debian': {
       $nrpe_config_basedir  = '/etc/nagios'
@@ -366,7 +368,8 @@ class icinga2::params {
       $nrpe_user            = 'nagios'
       $nrpe_group           = 'nagios'
     }
-    #Fail if we're on any other OS:
+   
+   #Fail if we're on any other OS:
     default: { fail("${::operatingsystem} is not supported!") }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,12 @@ class icinga2::params {
      #Pick the right package provider:
       $package_provider = 'yum'
     }
+	
+	#RedHat systems:
+    'RedHat': {
+      #Pick the right package provider:
+      $package_provider = 'yum'
+    }
 
     #Ubuntu systems:
     'Ubuntu': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,7 +18,7 @@ class icinga2::params {
   ##################
   # Icinga 2 common package parameters
   case $::operatingsystem {
-    #CentOS systems:
+    #CentOS or RedHat systems:
     'CentOS', 'RedHat': {
      #Pick the right package provider:
       $package_provider = 'yum'
@@ -94,6 +94,7 @@ class icinga2::params {
         default: { fail("${::operatingsystemmajrelease} is not a supported CentOS release!") }
       }
     }
+
     #RedHat systems:
     'RedHat': {
       case $::operatingsystemmajrelease {
@@ -119,7 +120,6 @@ class icinga2::params {
         default: { fail("${::operatingsystemmajrelease} is not a supported RedHat release!") }
       }
     }
-
 
     #Ubuntu systems:
     'Ubuntu': {
@@ -348,6 +348,7 @@ class icinga2::params {
       $nrpe_user           = 'nrpe'
       $nrpe_group          = 'nrpe'
     }
+
     #File and template variable names for Ubuntu systems:
     'Ubuntu': {
       $nrpe_config_basedir  = '/etc/nagios'
@@ -357,6 +358,7 @@ class icinga2::params {
       $nrpe_user            = 'nagios'
       $nrpe_group           = 'nagios'
     }
+
     #File and template variable names for Ubuntu systems:
     'Debian': {
       $nrpe_config_basedir  = '/etc/nagios'
@@ -366,7 +368,8 @@ class icinga2::params {
       $nrpe_user            = 'nagios'
       $nrpe_group           = 'nagios'
     }
-    #Fail if we're on any other OS:
+   
+   #Fail if we're on any other OS:
     default: { fail("${::operatingsystem} is not supported!") }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,18 +18,12 @@ class icinga2::params {
   ##################
   # Icinga 2 common package parameters
   case $::operatingsystem {
-    #CentOS systems:
+    #CentOS or RedHat systems:
     'CentOS', 'RedHat': {
       #Pick the right package provider:
       $package_provider = 'yum'
     }
 	
-	#RedHat systems:
-    'RedHat': {
-      #Pick the right package provider:
-      $package_provider = 'yum'
-    }
-
     #Ubuntu systems:
     'Ubuntu': {
       #Pick the right package provider:
@@ -101,7 +95,7 @@ class icinga2::params {
       }
     }
 
-    #Ubuntu systems:
+   #Ubuntu systems:
     'Ubuntu': {
       case $::operatingsystemrelease {
         #Ubuntu 12.04 doesn't have nagios-plugins-common or nagios-plugins-contrib packages available...
@@ -149,7 +143,7 @@ class icinga2::params {
   # Icinga 2 server config parameters
 
   case $::operatingsystem {
-    #CentOS systems:
+    #CentOS or RedHat systems:
     'CentOS', 'RedHat': {
       #Settings for /etc/icinga2/:
       $etc_icinga2_owner = 'icinga'
@@ -353,7 +347,7 @@ class icinga2::params {
   ##################
   # Icinga 2 client package parameters
   case $::operatingsystem {
-    #CentOS systems:
+    #CentOS or RedHat systems:
     'CentOS', 'RedHat': {
       case $::operatingsystemmajrelease {
         '5': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,7 +24,7 @@ class icinga2::params {
       $package_provider = 'yum'
     }
 
-    #Ubuntu systems:
+   #Ubuntu systems:
     'Ubuntu': {
       #Pick the right package provider:
       $package_provider = 'apt'
@@ -95,7 +95,7 @@ class icinga2::params {
       }
     }
 
-  #Ubuntu systems:
+   #Ubuntu systems:
     'Ubuntu': {
      case $::operatingsystemrelease {
         #Ubuntu 12.04 doesn't have nagios-plugins-common or nagios-plugins-contrib packages available...

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,7 +23,7 @@ class icinga2::params {
      #Pick the right package provider:
       $package_provider = 'yum'
     }
-	
+
     #Ubuntu systems:
     'Ubuntu': {
       #Pick the right package provider:
@@ -97,7 +97,7 @@ class icinga2::params {
 
   #Ubuntu systems:
     'Ubuntu': {
-      case $::operatingsystemrelease {
+     case $::operatingsystemrelease {
         #Ubuntu 12.04 doesn't have nagios-plugins-common or nagios-plugins-contrib packages available...
         '12.04': {
           $icinga2_server_package = 'icinga2'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,18 +18,12 @@ class icinga2::params {
   ##################
   # Icinga 2 common package parameters
   case $::operatingsystem {
-    #CentOS systems:
-    'CentOS': {
+    #CentOS or RedHat systems:
+    /(CentOS|RedHat)/': {
       #Pick the right package provider:
       $package_provider = 'yum'
     }
 	
-	#RedHat systems:
-    'RedHat': {
-      #Pick the right package provider:
-      $package_provider = 'yum'
-    }
-
     #Ubuntu systems:
     'Ubuntu': {
       #Pick the right package provider:
@@ -100,6 +94,32 @@ class icinga2::params {
         default: { fail("${::operatingsystemmajrelease} is not a supported CentOS release!") }
       }
     }
+    #RedHat systems:
+    'RedHat': {
+      case $::operatingsystemmajrelease {
+        '5': {
+          #Icinga 2 server package
+          $icinga2_server_package = 'icinga2'
+          $icinga2_server_plugin_packages = ['nagios-plugins-nrpe', 'nagios-plugins-all', 'nagios-plugins-openmanage', 'nagios-plugins-check-updates']
+          $icinga2_server_mail_package = 'mailx'
+        }
+        '6': {
+          #Icinga 2 server package
+          $icinga2_server_package = 'icinga2'
+          $icinga2_server_plugin_packages = ['nagios-plugins-nrpe', 'nagios-plugins-all', 'nagios-plugins-openmanage', 'nagios-plugins-check-updates']
+          $icinga2_server_mail_package = 'mailx'
+        }
+        '7': {
+          #Icinga 2 server package
+          $icinga2_server_package = 'icinga2'
+          $icinga2_server_plugin_packages = ['nagios-plugins-nrpe', 'nagios-plugins-all', 'nagios-plugins-openmanage', 'nagios-plugins-check-updates']
+          $icinga2_server_mail_package = 'mailx'
+        }
+        #Fail if we're on any other RedHat release:
+        default: { fail("${::operatingsystemmajrelease} is not a supported RedHat release!") }
+      }
+    }
+
 
     #Ubuntu systems:
     'Ubuntu': {
@@ -149,8 +169,8 @@ class icinga2::params {
   # Icinga 2 server config parameters
 
   case $::operatingsystem {
-    #CentOS systems:
-    'CentOS': {
+    #CentOS or RedHat systems:
+    /(Centos|RedHat)/: {
       #Settings for /etc/icinga2/:
       $etc_icinga2_owner = 'icinga'
       $etc_icinga2_group = 'icinga'
@@ -250,7 +270,7 @@ class icinga2::params {
 
   case $::operatingsystem {
     #Icinga 2 server daemon names for Red Had/CentOS systems:
-    'CentOS': {
+    /(Centos|RedHat)/: {
       case $::operatingsystemmajrelease {
         '5': {
           $icinga2_server_service_name = 'icinga2'
@@ -320,7 +340,7 @@ class icinga2::params {
 
   case $::operatingsystem {
     #File and template variable names for Red Had/CentOS systems:
-    'CentOS': {
+    /(Centos|RedHat)/: {
       $nrpe_config_basedir = '/etc/nagios'
       $nrpe_plugin_libdir  = '/usr/lib64/nagios/plugins'
       $checkplugin_libdir  = '/usr/lib64/nagios/plugins'
@@ -353,8 +373,8 @@ class icinga2::params {
   ##################
   # Icinga 2 client package parameters
   case $::operatingsystem {
-    #CentOS systems:
-    'CentOS': {
+    #CentOS or RedHat systems:
+    /(CentOS|RedHat)/: {
       case $::operatingsystemmajrelease {
         '5': {
           #Pick the right list of client packages:
@@ -415,7 +435,7 @@ class icinga2::params {
   # Icinga 2 client service parameters
   case $::operatingsystem {
     #Daemon names for Red Had/CentOS systems:
-    'CentOS': {
+    /(CentOS|RedHat)/: {
       $nrpe_daemon_name = 'nrpe'
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class icinga2::params {
   # Icinga 2 common package parameters
   case $::operatingsystem {
     #CentOS systems:
-    'CentOS': {
+    'CentOS', 'RedHat': {
       #Pick the right package provider:
       $package_provider = 'yum'
     }
@@ -76,7 +76,7 @@ class icinga2::params {
   #Pick the right package parameters based on the OS:
   case $::operatingsystem {
     #CentOS systems:
-    'CentOS': {
+    'CentOS', 'RedHat': {
       case $::operatingsystemmajrelease {
         '5': {
           #Icinga 2 server package
@@ -150,7 +150,7 @@ class icinga2::params {
 
   case $::operatingsystem {
     #CentOS systems:
-    'CentOS': {
+    'CentOS', 'RedHat': {
       #Settings for /etc/icinga2/:
       $etc_icinga2_owner = 'icinga'
       $etc_icinga2_group = 'icinga'
@@ -250,7 +250,7 @@ class icinga2::params {
 
   case $::operatingsystem {
     #Icinga 2 server daemon names for Red Had/CentOS systems:
-    'CentOS': {
+    'CentOS', 'RedHat': {
       case $::operatingsystemmajrelease {
         '5': {
           $icinga2_server_service_name = 'icinga2'
@@ -320,7 +320,7 @@ class icinga2::params {
 
   case $::operatingsystem {
     #File and template variable names for Red Had/CentOS systems:
-    'CentOS': {
+    'CentOS', 'RedHat': {
       $nrpe_config_basedir = '/etc/nagios'
       $nrpe_plugin_libdir  = '/usr/lib64/nagios/plugins'
       $checkplugin_libdir  = '/usr/lib64/nagios/plugins'
@@ -354,7 +354,7 @@ class icinga2::params {
   # Icinga 2 client package parameters
   case $::operatingsystem {
     #CentOS systems:
-    'CentOS': {
+    'CentOS', 'RedHat': {
       case $::operatingsystemmajrelease {
         '5': {
           #Pick the right list of client packages:
@@ -415,7 +415,7 @@ class icinga2::params {
   # Icinga 2 client service parameters
   case $::operatingsystem {
     #Daemon names for Red Had/CentOS systems:
-    'CentOS': {
+    'CentOS', 'RedHat': {
       $nrpe_daemon_name = 'nrpe'
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -94,6 +94,32 @@ class icinga2::params {
         default: { fail("${::operatingsystemmajrelease} is not a supported CentOS release!") }
       }
     }
+    #RedHat systems:
+    'RedHat': {
+      case $::operatingsystemmajrelease {
+        '5': {
+          #Icinga 2 server package
+          $icinga2_server_package = 'icinga2'
+          $icinga2_server_plugin_packages = ['nagios-plugins-nrpe', 'nagios-plugins-all', 'nagios-plugins-openmanage', 'nagios-plugins-check-updates']
+          $icinga2_server_mail_package = 'mailx'
+        }
+        '6': {
+          #Icinga 2 server package
+          $icinga2_server_package = 'icinga2'
+          $icinga2_server_plugin_packages = ['nagios-plugins-nrpe', 'nagios-plugins-all', 'nagios-plugins-openmanage', 'nagios-plugins-check-updates']
+          $icinga2_server_mail_package = 'mailx'
+        }
+        '7': {
+          #Icinga 2 server package
+          $icinga2_server_package = 'icinga2'
+          $icinga2_server_plugin_packages = ['nagios-plugins-nrpe', 'nagios-plugins-all', 'nagios-plugins-openmanage', 'nagios-plugins-check-updates']
+          $icinga2_server_mail_package = 'mailx'
+        }
+        #Fail if we're on any other RedHat release:
+        default: { fail("${::operatingsystemmajrelease} is not a supported RedHat release!") }
+      }
+    }
+
 
     #Ubuntu systems:
     'Ubuntu': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,18 +18,11 @@ class icinga2::params {
   ##################
   # Icinga 2 common package parameters
   case $::operatingsystem {
-    #CentOS systems:
+    #CentOS or RedHat systems:
     'CentOS', 'RedHat': {
       #Pick the right package provider:
       $package_provider = 'yum'
     }
-	
-	#RedHat systems:
-    'RedHat': {
-      #Pick the right package provider:
-      $package_provider = 'yum'
-    }
-
     #Ubuntu systems:
     'Ubuntu': {
       #Pick the right package provider:
@@ -101,7 +94,7 @@ class icinga2::params {
       }
     }
 
-    #Ubuntu systems:
+   #Ubuntu systems:
     'Ubuntu': {
       case $::operatingsystemrelease {
         #Ubuntu 12.04 doesn't have nagios-plugins-common or nagios-plugins-contrib packages available...
@@ -149,7 +142,7 @@ class icinga2::params {
   # Icinga 2 server config parameters
 
   case $::operatingsystem {
-    #CentOS systems:
+    #CentOS or RedHat systems:
     'CentOS', 'RedHat': {
       #Settings for /etc/icinga2/:
       $etc_icinga2_owner = 'icinga'
@@ -328,6 +321,7 @@ class icinga2::params {
       $nrpe_user           = 'nrpe'
       $nrpe_group          = 'nrpe'
     }
+
     #File and template variable names for Ubuntu systems:
     'Ubuntu': {
       $nrpe_config_basedir  = '/etc/nagios'
@@ -337,6 +331,7 @@ class icinga2::params {
       $nrpe_user            = 'nagios'
       $nrpe_group           = 'nagios'
     }
+
     #File and template variable names for Ubuntu systems:
     'Debian': {
       $nrpe_config_basedir  = '/etc/nagios'
@@ -346,14 +341,15 @@ class icinga2::params {
       $nrpe_user            = 'nagios'
       $nrpe_group           = 'nagios'
     }
-    #Fail if we're on any other OS:
+   
+   #Fail if we're on any other OS:
     default: { fail("${::operatingsystem} is not supported!") }
   }
 
   ##################
   # Icinga 2 client package parameters
   case $::operatingsystem {
-    #CentOS systems:
+    #CentOS or RedHat systems:
     'CentOS', 'RedHat': {
       case $::operatingsystemmajrelease {
         '5': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,13 +20,7 @@ class icinga2::params {
   case $::operatingsystem {
     #CentOS systems:
     'CentOS', 'RedHat': {
-      #Pick the right package provider:
-      $package_provider = 'yum'
-    }
-	
-	#RedHat systems:
-    'RedHat': {
-      #Pick the right package provider:
+     #Pick the right package provider:
       $package_provider = 'yum'
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,12 @@ class icinga2::params {
      #Pick the right package provider:
       $package_provider = 'yum'
     }
+	
+	#RedHat systems:
+    'RedHat': {
+      #Pick the right package provider:
+      $package_provider = 'yum'
+    }
 
    #Ubuntu systems:
    'Ubuntu': {
@@ -96,7 +102,7 @@ class icinga2::params {
     }
 
    #Ubuntu systems:
-    'Ubuntu': {
+   'Ubuntu': {
     case $::operatingsystemrelease {
         #Ubuntu 12.04 doesn't have nagios-plugins-common or nagios-plugins-contrib packages available...
         '12.04': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,7 +23,7 @@ class icinga2::params {
       #Pick the right package provider:
       $package_provider = 'yum'
     }
-	
+
     #Ubuntu systems:
     'Ubuntu': {
       #Pick the right package provider:
@@ -94,9 +94,8 @@ class icinga2::params {
         default: { fail("${::operatingsystemmajrelease} is not a supported CentOS release!") }
       }
     }
-
    #Ubuntu systems:
-    'Ubuntu': {
+   'Ubuntu': {
       case $::operatingsystemrelease {
         #Ubuntu 12.04 doesn't have nagios-plugins-common or nagios-plugins-contrib packages available...
         '12.04': {
@@ -322,6 +321,7 @@ class icinga2::params {
       $nrpe_user           = 'nrpe'
       $nrpe_group          = 'nrpe'
     }
+
     #File and template variable names for Ubuntu systems:
     'Ubuntu': {
       $nrpe_config_basedir  = '/etc/nagios'
@@ -331,6 +331,7 @@ class icinga2::params {
       $nrpe_user            = 'nagios'
       $nrpe_group           = 'nagios'
     }
+
     #File and template variable names for Ubuntu systems:
     'Debian': {
       $nrpe_config_basedir  = '/etc/nagios'
@@ -340,7 +341,8 @@ class icinga2::params {
       $nrpe_user            = 'nagios'
       $nrpe_group           = 'nagios'
     }
-    #Fail if we're on any other OS:
+   
+   #Fail if we're on any other OS:
     default: { fail("${::operatingsystem} is not supported!") }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,12 +24,6 @@ class icinga2::params {
       $package_provider = 'yum'
     }
 	
-	#RedHat systems:
-    'RedHat': {
-      #Pick the right package provider:
-      $package_provider = 'yum'
-    }
-
     #Ubuntu systems:
     'Ubuntu': {
       #Pick the right package provider:
@@ -101,33 +95,7 @@ class icinga2::params {
       }
     }
 
-    #RedHat systems:
-    'RedHat': {
-      case $::operatingsystemmajrelease {
-        '5': {
-          #Icinga 2 server package
-          $icinga2_server_package = 'icinga2'
-          $icinga2_server_plugin_packages = ['nagios-plugins-nrpe', 'nagios-plugins-all', 'nagios-plugins-openmanage', 'nagios-plugins-check-updates']
-          $icinga2_server_mail_package = 'mailx'
-        }
-        '6': {
-          #Icinga 2 server package
-          $icinga2_server_package = 'icinga2'
-          $icinga2_server_plugin_packages = ['nagios-plugins-nrpe', 'nagios-plugins-all', 'nagios-plugins-openmanage', 'nagios-plugins-check-updates']
-          $icinga2_server_mail_package = 'mailx'
-        }
-        '7': {
-          #Icinga 2 server package
-          $icinga2_server_package = 'icinga2'
-          $icinga2_server_plugin_packages = ['nagios-plugins-nrpe', 'nagios-plugins-all', 'nagios-plugins-openmanage', 'nagios-plugins-check-updates']
-          $icinga2_server_mail_package = 'mailx'
-        }
-        #Fail if we're on any other RedHat release:
-        default: { fail("${::operatingsystemmajrelease} is not a supported RedHat release!") }
-      }
-    }
-
-    #Ubuntu systems:
+  #Ubuntu systems:
     'Ubuntu': {
       case $::operatingsystemrelease {
         #Ubuntu 12.04 doesn't have nagios-plugins-common or nagios-plugins-contrib packages available...
@@ -175,7 +143,7 @@ class icinga2::params {
   # Icinga 2 server config parameters
 
   case $::operatingsystem {
-    #CentOS systems:
+    #CentOS or RedHat systems:
     'CentOS', 'RedHat': {
       #Settings for /etc/icinga2/:
       $etc_icinga2_owner = 'icinga'
@@ -382,7 +350,7 @@ class icinga2::params {
   ##################
   # Icinga 2 client package parameters
   case $::operatingsystem {
-    #CentOS systems:
+    #CentOS or RedHat systems:
     'CentOS', 'RedHat': {
       case $::operatingsystemmajrelease {
         '5': {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -53,15 +53,6 @@ class icinga2::server (
       }
     }
 
-    'RedHat': {
-      #...and database that the user picks
-      case $server_db_type {
-        'mysql': { $server_db_schema_path = '/usr/share/icinga2-ido-mysql/schema/mysql.sql' }
-        'pgsql': { $server_db_schema_path = '/usr/share/icinga2-ido-pgsql/schema/pgsql.sql' }
-        default: { fail("${server_db_type} is not a supported database! Please specify either 'mysql' for MySQL or 'pgsql' for Postgres.") }
-      }
-    }
-
     #Ubuntu systems:
     'Ubuntu': {
       #Pick set the right path where we can find the DB schema

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -44,16 +44,7 @@ class icinga2::server (
 
   #Pick set the right path where we can find the DB schema based on the OS...
   case $::operatingsystem {
-    'CentOS': {
-      #...and database that the user picks
-      case $server_db_type {
-        'mysql': { $server_db_schema_path = '/usr/share/icinga2-ido-mysql/schema/mysql.sql' }
-        'pgsql': { $server_db_schema_path = '/usr/share/icinga2-ido-pgsql/schema/pgsql.sql' }
-        default: { fail("${server_db_type} is not a supported database! Please specify either 'mysql' for MySQL or 'pgsql' for Postgres.") }
-      }
-    }
-
-    'RedHat': {
+    'CentOS','RedHat': {
       #...and database that the user picks
       case $server_db_type {
         'mysql': { $server_db_schema_path = '/usr/share/icinga2-ido-mysql/schema/mysql.sql' }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -53,6 +53,15 @@ class icinga2::server (
       }
     }
 
+    'RedHat': {
+      #...and database that the user picks
+      case $server_db_type {
+        'mysql': { $server_db_schema_path = '/usr/share/icinga2-ido-mysql/schema/mysql.sql' }
+        'pgsql': { $server_db_schema_path = '/usr/share/icinga2-ido-pgsql/schema/pgsql.sql' }
+        default: { fail("${server_db_type} is not a supported database! Please specify either 'mysql' for MySQL or 'pgsql' for Postgres.") }
+      }
+    }
+
     #Ubuntu systems:
     'Ubuntu': {
       #Pick set the right path where we can find the DB schema

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -33,7 +33,7 @@ class icinga2::server::install::repos inherits icinga2::server {
   if $manage_repos == true {
     case $::operatingsystem {
       #CentOS systems:
-      'CentOS': {
+      'CentOS', 'RedHat': {
 
         #Add the official Icinga Yum repository: http://packages.icinga.org/epel/
         yumrepo { 'icinga2_yum_repo':

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -32,7 +32,7 @@ class icinga2::server::install::repos inherits icinga2::server {
 
   if $manage_repos == true {
     case $::operatingsystem {
-      #CentOS systems:
+      #CentOS or RedHat systems:
       'CentOS', 'RedHat': {
         #Add the official Icinga Yum repository: http://packages.icinga.org/epel/
         yumrepo { 'icinga2_yum_repo':

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -32,9 +32,8 @@ class icinga2::server::install::repos inherits icinga2::server {
 
   if $manage_repos == true {
     case $::operatingsystem {
-      #CentOS systems:
+      #CentOS or RedHat systems:
       'CentOS', 'RedHat': {
-
         #Add the official Icinga Yum repository: http://packages.icinga.org/epel/
         yumrepo { 'icinga2_yum_repo':
           baseurl  => "http://packages.icinga.org/epel/${::operatingsystemmajrelease}/release/",
@@ -45,20 +44,7 @@ class icinga2::server::install::repos inherits icinga2::server {
         }
       }
 
-      #RedHat systems:
-      'RedHat': {
-
-        #Add the official Icinga Yum repository: http://packages.icinga.org/epel/
-        yumrepo { 'icinga2_yum_repo':
-          baseurl  => "http://packages.icinga.org/epel/${::operatingsystemmajrelease}/release/",
-          descr    => 'Icinga 2 Yum repository',
-          enabled  => 1,
-          gpgcheck => 1,
-          gpgkey   => 'http://packages.icinga.org/icinga.key'
-        }
-      }
-
-      #Ubuntu systems:
+     #Ubuntu systems:
       'Ubuntu': {
         #Include the apt module's base class so we can...
         include apt

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -32,8 +32,8 @@ class icinga2::server::install::repos inherits icinga2::server {
 
   if $manage_repos == true {
     case $::operatingsystem {
-      #CentOS systems:
-      'CentOS': {
+      #CentOS or RedHat systems:
+      /(CentOS|RedHat)/: {
 
         #Add the official Icinga Yum repository: http://packages.icinga.org/epel/
         yumrepo { 'icinga2_yum_repo':
@@ -45,20 +45,7 @@ class icinga2::server::install::repos inherits icinga2::server {
         }
       }
 
-      #RedHat systems:
-      'RedHat': {
-
-        #Add the official Icinga Yum repository: http://packages.icinga.org/epel/
-        yumrepo { 'icinga2_yum_repo':
-          baseurl  => "http://packages.icinga.org/epel/${::operatingsystemmajrelease}/release/",
-          descr    => 'Icinga 2 Yum repository',
-          enabled  => 1,
-          gpgcheck => 1,
-          gpgkey   => 'http://packages.icinga.org/icinga.key'
-        }
-      }
-
-      #Ubuntu systems:
+     #Ubuntu systems:
       'Ubuntu': {
         #Include the apt module's base class so we can...
         include apt

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -45,7 +45,7 @@ class icinga2::server::install::repos inherits icinga2::server {
       }
 
      #Ubuntu systems:
-      'Ubuntu': {
+     'Ubuntu': {
         #Include the apt module's base class so we can...
         include apt
         #...use the apt module to add the Icinga 2 PPA from launchpad.net:

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -45,6 +45,19 @@ class icinga2::server::install::repos inherits icinga2::server {
         }
       }
 
+      #RedHat systems:
+      'RedHat': {
+
+        #Add the official Icinga Yum repository: http://packages.icinga.org/epel/
+        yumrepo { 'icinga2_yum_repo':
+          baseurl  => "http://packages.icinga.org/epel/${::operatingsystemmajrelease}/release/",
+          descr    => 'Icinga 2 Yum repository',
+          enabled  => 1,
+          gpgcheck => 1,
+          gpgkey   => 'http://packages.icinga.org/icinga.key'
+        }
+      }
+
       #Ubuntu systems:
       'Ubuntu': {
         #Include the apt module's base class so we can...

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -34,7 +34,6 @@ class icinga2::server::install::repos inherits icinga2::server {
     case $::operatingsystem {
       #CentOS systems:
       'CentOS', 'RedHat': {
-
         #Add the official Icinga Yum repository: http://packages.icinga.org/epel/
         yumrepo { 'icinga2_yum_repo':
           baseurl  => "http://packages.icinga.org/epel/${::operatingsystemmajrelease}/release/",
@@ -45,20 +44,7 @@ class icinga2::server::install::repos inherits icinga2::server {
         }
       }
 
-      #RedHat systems:
-      'RedHat': {
-
-        #Add the official Icinga Yum repository: http://packages.icinga.org/epel/
-        yumrepo { 'icinga2_yum_repo':
-          baseurl  => "http://packages.icinga.org/epel/${::operatingsystemmajrelease}/release/",
-          descr    => 'Icinga 2 Yum repository',
-          enabled  => 1,
-          gpgcheck => 1,
-          gpgkey   => 'http://packages.icinga.org/icinga.key'
-        }
-      }
-
-      #Ubuntu systems:
+     #Ubuntu systems:
       'Ubuntu': {
         #Include the apt module's base class so we can...
         include apt

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -45,7 +45,7 @@ class icinga2::server::install::repos inherits icinga2::server {
       }
 
      #Ubuntu systems:
-     'Ubuntu': {
+      'Ubuntu': {
         #Include the apt module's base class so we can...
         include apt
         #...use the apt module to add the Icinga 2 PPA from launchpad.net:

--- a/metadata.json
+++ b/metadata.json
@@ -17,6 +17,14 @@
       ]
     },
     {
+      "operatingsystem": "RedHat",
+      "operatingsystemmajrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
       "operatingsystem": "Debian",
       "operatingsystemmajrelease": [
         "7"


### PR DESCRIPTION
I noticed that installation on RedHat did not work out of the box so I added a few lines to make this possible. I have already tested it on a RHEL 6.6 connected to a satellite with the icinga2 packages residing in a subchannel. Please review my changes if they meet your standards. I would appreciate seeing them in the upstream code.
