### PR TITLE
Changing facts to core_facsts

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -115,7 +115,7 @@ class icinga2::params {
           $server_plugin_package_install_options = '--no-install-recommends'
         }
         #Fail if we're on any other Ubuntu release:
-        default: { fail("${::operatingsystemmajrelease} is not a supported Ubuntu release version!") }
+        default: { fail("${::operatingsystemrelease} is not a supported Ubuntu release version!") }
       }
     }
 
@@ -262,7 +262,7 @@ class icinga2::params {
 
     #Icinga 2 server daemon names for Ubuntu systems:
     'Ubuntu': {
-      case $::operatingsystemmajrelease {
+      case $::operatingsystemrelease {
         '12.04': {
           $icinga2_server_service_name = 'icinga2'
         }
@@ -270,7 +270,7 @@ class icinga2::params {
           $icinga2_server_service_name = 'icinga2'
         }
         #Fail if we're on any other Ubuntu release:
-        default: { fail("${::operatingsystemmajrelease} is not a supported Ubuntu release version!") }
+        default: { fail("${::operatingsystemrelease} is not a supported Ubuntu release version!") }
       }
     }
 
@@ -384,7 +384,7 @@ class icinga2::params {
           $client_plugin_package_install_options = '--no-install-recommends'
         }
         #Fail if we're on any other Ubuntu release:
-        default: { fail("${::operatingsystemmajrelease} is not a supported Ubuntu release version!") }
+        default: { fail("${::operatingsystemrelease} is not a supported Ubuntu release version!") }
       }
     }
 


### PR DESCRIPTION
Changed to operatingsystemrelease for ubuntu systems. The fact is a core fact now for ubuntu as documented in 
https://docs.puppetlabs.com/facter/1.6/core_facts.html#operatingsystemrelease
