### PR TITLE
Fix undefined script variable error

### DIFF
--- a/templates/object_apply_service_to_host.conf.erb
+++ b/templates/object_apply_service_to_host.conf.erb
@@ -43,7 +43,7 @@ apply Service "<%= @object_servicename %>" to Host {
   max_check_attempts = <%= @max_check_attempts %>
   <%- end -%>
   <%- if @check_period -%>
-  check_period = <%= @check_period %>
+  check_period = "<%= @check_period %>"
   <%- end -%>
   <%- if @check_interval -%>
   check_interval = <%= @check_interval %>


### PR DESCRIPTION
Consider following snippet: 

```
apply Service "check_updates" to Host {
  ...
  check_command = "nrpe"
  period = officehours
}
```

which causes:

```
icinga icinga2[26289]: /etc/icinga2/objects/applys/check_updates.conf(20):   period = officehours
icinga icinga2[26289]: ^^^^^^^^^^^
```

... and is fixed by quoting "officehours".
