### PR TITLE
Apply Notification objects 'interval' parameter generates invalid configs

### DIFF
--- a/templates/object_apply_notification_to_host.conf.erb
+++ b/templates/object_apply_notification_to_host.conf.erb
@@ -50,7 +50,7 @@ apply Notification "<%= @object_notificationname %>" to Host {
   }
   <%- end -%>
   <%- if @interval -%>
-  interval = "<%= @interval -%>"
+  interval = <%= @interval %>
   <%- end -%>
   <%- if @period -%>
   period = "<%= @period -%>"

--- a/templates/object_apply_notification_to_service.conf.erb
+++ b/templates/object_apply_notification_to_service.conf.erb
@@ -53,7 +53,7 @@ apply Notification "<%= @object_notificationname %>" to Service {
   }
   <%- end -%>
   <%- if @interval -%>
-  interval = "<%= @interval -%>"
+  interval = <%= @interval %>
   <%- end -%>
   <%- if @period -%>
   period = "<%= @period -%>"


### PR DESCRIPTION
Fixed 'interval' parameter for the apply notification objects to not be quoted in the generated configuration.
