### PR TITLE
Add param for purging zones.d directory

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,7 +16,6 @@ class icinga2::config {
       '/etc/icinga2',
       '/etc/icinga2/pki',
       '/etc/icinga2/scripts',
-      '/etc/icinga2/zones.d',
     ]:
       ensure => directory,
   }
@@ -37,6 +36,7 @@ class icinga2::config {
       '/etc/icinga2/features-available',
       '/etc/icinga2/features-enabled',
       '/etc/icinga2/objects',
+      '/etc/icinga2/zones.d',
     ]:
       ensure  => directory,
       purge   => $::icinga2::purge_configs,


### PR DESCRIPTION
Useful when using automatic zone config propagation and managing
all configs in zones.d/ using puppet.

I'm not sure why you mention the purge_confd parameter being temporary. If you think this zones.d/ purging should be done differently, please let me know. I'm still quite new to Icinga configuration and might have missed something.
