### PR TITLE
Don't put a vars. array in ""

### DIFF
--- a/templates/object_apply_service_to_host.conf.erb
+++ b/templates/object_apply_service_to_host.conf.erb
@@ -39,7 +39,11 @@ apply Service "<%= @object_servicename %>" to Host {
   <%- end -%>
   <%- if @vars.empty? != true  -%>
   <%- @vars.sort_by {|key, value| key}.each do |key, value| -%>
+  <%- if value.is_a?(Array) -%>
+  vars.<%= key %> = <%= value %>
+  <%- else -%>	  
   vars.<%= key %> = "<%= value %>"
+  <%- end -%>
   <%- end -%>
   <%- end -%>
   <%- if @max_check_attempts -%>

--- a/templates/object_host.conf.erb
+++ b/templates/object_host.conf.erb
@@ -37,7 +37,11 @@ object Host "<%= @object_hostname %>" {
   <%- end -%>
   }
   <%- else -%>
+  <%- if value.is_a?(Array) -%>
+  vars.<%= key %> = <%= value %>
+  <%- else -%>
   vars.<%= key %> = "<%= value %>"
+  <%- end -%>
   <%- end -%>
   <%- end -%>
   <%- end -%>


### PR DESCRIPTION
arrays were written like

```
vars.array = "["foo", "bar"]"
```

which is a wrong syntax. this pull request changes it and removes the extra "" if it is an array. result is:

```
vars.array = ["foo", "bar"]
```
