### PR TITLE
Properly purge unmanaged files in the objects/* subdirectories

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -25,7 +25,7 @@ class icinga2::server::config inherits icinga2::server {
     $purge_objects = false
     $force_purge = true
   }
-  
+
 
   #Directory resource for /etc/icinga2/:
   file { '/etc/icinga2/':
@@ -118,272 +118,361 @@ class icinga2::server::config inherits icinga2::server {
 
   #Directory resource for /etc/icinga2/objects/hosts/:
   file { '/etc/icinga2/objects/hosts/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/hosts/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/hosts/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/hostgroups/:
   file { '/etc/icinga2/objects/hostgroups/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/hostgroups/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/hostgroups/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/services/:
   file { '/etc/icinga2/objects/services/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/services/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/services/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/servicegroups/:
   file { '/etc/icinga2/objects/servicegroups/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/servicegroups/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/servicegroups/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/users/:
   file { '/etc/icinga2/objects/users/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/users/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/users/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/usergroups/:
   file { '/etc/icinga2/objects/usergroups/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/usergroups/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/usergroups/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/checkcommands/:
   file { '/etc/icinga2/objects/checkcommands/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/checkcommands/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/checkcommands/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/notificationcommands/:
   file { '/etc/icinga2/objects/notificationcommands/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/notificationcommands/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/notificationcommands/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/eventcommands/:
   file { '/etc/icinga2/objects/eventcommands/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/eventcommands/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/eventcommands/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/notifications/:
   file { '/etc/icinga2/objects/notifications/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/notifications/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/notifications/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/timeperiods/:
   file { '/etc/icinga2/objects/timeperiods/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/timeperiods/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/timeperiods/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/scheduleddowntimes/:
   file { '/etc/icinga2/objects/scheduleddowntimes/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/scheduleddowntimes/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/scheduleddowntimes/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/dependencies/:
   file { '/etc/icinga2/objects/dependencies/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/dependencies/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/dependencies/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/perfdatawriters/:
   file { '/etc/icinga2/objects/perfdatawriters/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/perfdatawriters/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/perfdatawriters/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/graphitewriters/:
   file { '/etc/icinga2/objects/graphitewriters/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/graphitewriters/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
-  }
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/graphitewriters/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
 
   #Directory resource for /etc/icinga2/objects/idomysqlconnections/:
   file { '/etc/icinga2/objects/idomysqlconnections/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/idomysqlconnections/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/idomysqlconnections/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/idopgsqlconnections/:
   file { '/etc/icinga2/objects/idopgsqlconnections/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/idopgsqlconnections/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/idopgsqlconnections/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/livestatuslisteners/:
   file { '/etc/icinga2/objects/livestatuslisteners/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/livestatuslisteners/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/livestatuslisteners/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/statusdatawriters/:
   file { '/etc/icinga2/objects/statusdatawriters/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/statusdatawriters/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/statusdatawriters/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/externalcommandlisteners/:
   file { '/etc/icinga2/objects/externalcommandlisteners/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/externalcommandlisteners/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/externalcommandlisteners/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/compatloggers/:
   file { '/etc/icinga2/objects/compatloggers/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/compatloggers/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/compatloggers/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/checkresultreaders/:
   file { '/etc/icinga2/objects/checkresultreaders/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/checkresultreaders/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/checkresultreaders/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/checkercomponents/:
   file { '/etc/icinga2/objects/checkercomponents/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/checkercomponents/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/checkercomponents/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/notificationcomponents/:
   file { '/etc/icinga2/objects/notificationcomponents/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/notificationcomponents/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/notificationcomponents/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/fileloggers/:
   file { '/etc/icinga2/objects/fileloggers/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/fileloggers/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/fileloggers/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/syslogloggers/:
   file { '/etc/icinga2/objects/syslogloggers/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/syslogloggers/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/syslogloggers/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/icingastatuswriters/:
   file { '/etc/icinga2/objects/icingastatuswriters/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/icingastatuswriters/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/icingastatuswriters/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/apilisteners/:
   file { '/etc/icinga2/objects/apilisteners/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/apilisteners/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/apilisteners/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/endpoints/:
   file { '/etc/icinga2/objects/endpoints/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/endpoints/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/endpoints/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/zones/:
   file { '/etc/icinga2/objects/zones/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/zones/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/zones/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/applys/
@@ -392,30 +481,39 @@ class icinga2::server::config inherits icinga2::server {
   #See the following link for more info:
   # http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc#!/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#apply
   file { '/etc/icinga2/objects/applys/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/applys/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/applys/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
   #Directory resource for /etc/icinga2/objects/templates/:
   file { '/etc/icinga2/objects/templates/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/templates/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/templates/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
 
   #Directory resource for /etc/icinga2/objects/constants/:
   file { '/etc/icinga2/objects/constants/':
-    ensure => directory,
-    path   => '/etc/icinga2/objects/constants/',
-    owner  => $etc_icinga2_obejcts_sub_dir_owner,
-    group  => $etc_icinga2_obejcts_sub_dir_group,
-    mode   => $etc_icinga2_obejcts_sub_dir_mode,
+    ensure  => directory,
+    path    => '/etc/icinga2/objects/constants/',
+    owner   => $etc_icinga2_obejcts_sub_dir_owner,
+    group   => $etc_icinga2_obejcts_sub_dir_group,
+    mode    => $etc_icinga2_obejcts_sub_dir_mode,
+    recurse => $recurse_objects,
+    purge   => $purge_objects,
+    force   => $force_purge
   }
 
 }


### PR DESCRIPTION
The purge_unmanaged_object_files parameter is applied to the objects
directory with recursion and force flags enabled, however this behaviour
seems to be turned back off by the file resources for each subdirectory
and as such unmanaged files are not really purged.

This commit copies the purge parameters from the parent objects directory
onto each child directory to enable the intended behaviour.
