### PR TITLE
Added  support for Debian 8 (Jessie)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,7 +23,7 @@ class icinga2::params {
      #Pick the right package provider:
       $package_provider = 'yum'
     }
-	
+
 	#RedHat systems:
     'RedHat': {
       #Pick the right package provider:
@@ -136,6 +136,13 @@ class icinga2::params {
           #Specify '--no-install-recommends' so we don't inadvertently get Nagios 3 installed; it comes as a recommended package with most of the plugin packages:
           $server_plugin_package_install_options = '--no-install-recommends'
         }
+        '8': {
+          $icinga2_server_package = 'icinga2'
+          $icinga2_server_plugin_packages = ['nagios-plugins', 'nagios-plugins-basic', 'nagios-plugins-standard', 'nagios-snmp-plugins', 'nagios-plugins-contrib', 'nagios-nrpe-plugin']
+          $icinga2_server_mail_package = 'mailutils'
+          #Specify '--no-install-recommends' so we don't inadvertently get Nagios 3 installed; it comes as a recommended package with most of the plugin packages:
+          $server_plugin_package_install_options = '--no-install-recommends'
+        }
         #Fail if we're on any other Debian release:
         default: { fail("${::operatingsystemmajrelease} is not a supported Debian release version!") }
       }
@@ -241,7 +248,7 @@ class icinga2::params {
     #Fail if we're on any other OS:
     default: { fail("${::operatingsystem} is not supported!") }
   }
-  
+
   #Whether to purge object files or directories in /etc/icinga2/objects that aren't managed by Puppet
   $purge_unmanaged_object_files = false
 
@@ -284,6 +291,9 @@ class icinga2::params {
     'Debian': {
       case $::operatingsystemmajrelease {
         '7': {
+          $icinga2_server_service_name = 'icinga2'
+        }
+        '8': {
           $icinga2_server_service_name = 'icinga2'
         }
         #Fail if we're on any other Debian release:
@@ -348,7 +358,7 @@ class icinga2::params {
       $nrpe_user            = 'nagios'
       $nrpe_group           = 'nagios'
     }
-   
+
    #Fail if we're on any other OS:
     default: { fail("${::operatingsystem} is not supported!") }
   }
@@ -401,6 +411,11 @@ class icinga2::params {
     'Debian': {
       case $::operatingsystemmajrelease {
         '7': {
+          $icinga2_client_packages = ['nagios-nrpe-server', 'nagios-plugins', 'nagios-plugins-basic', 'nagios-plugins-standard', 'nagios-snmp-plugins', 'nagios-plugins-contrib', 'nagios-nrpe-plugin']
+          #Specify '--no-install-recommends' so we don't inadvertently get Nagios 3 installed; it comes as a recommended package with most of the plugin packages:
+          $client_plugin_package_install_options = '--no-install-recommends'
+        }
+        '8': {
           $icinga2_client_packages = ['nagios-nrpe-server', 'nagios-plugins', 'nagios-plugins-basic', 'nagios-plugins-standard', 'nagios-snmp-plugins', 'nagios-plugins-contrib', 'nagios-nrpe-plugin']
           #Specify '--no-install-recommends' so we don't inadvertently get Nagios 3 installed; it comes as a recommended package with most of the plugin packages:
           $client_plugin_package_install_options = '--no-install-recommends'

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -56,20 +56,44 @@ class icinga2::server::install::repos inherits icinga2::server {
       #Debian systems:
       'Debian': {
         include apt
+        $icinga2_server_service_name = 'icinga2'
 
-        #On Debian (7) icinga2 packages are on backports
-        if $use_debmon_repo == false {
-          include apt::backports
-        } else {
-          apt::source { 'debmon':
-            location    => 'http://debmon.org/debmon',
-            release     => "debmon-${lsbdistcodename}",
-            repos       => 'main',
-            key_source  => 'http://debmon.org/debmon/repo.key',
-            key         => '29D662D2',
-            include_src => false,
-            # backports repo use 200
-            pin         => '300'
+        case $::operatingsystemmajrelease {
+          '7': {
+            #On Debian (7) icinga2 packages are on backports
+            if $use_debmon_repo == false {
+              include apt::backports
+            } else {
+              apt::source { 'debmon':
+                location    => 'http://debmon.org/debmon',
+                release     => "debmon-${lsbdistcodename}",
+                repos       => 'main',
+                key_source  => 'http://debmon.org/debmon/repo.key',
+                key         => '29D662D2',
+                include_src => false,
+                # backports repo use 200
+                pin         => '300'
+              }
+            }
+          }
+          '8': {
+            if $use_debmon_repo == true {
+              apt::source { 'debmon':
+                location    => 'http://debmon.org/debmon',
+                release     => "debmon-${lsbdistcodename}",
+                repos       => 'main',
+                key_source  => 'http://debmon.org/debmon/repo.key',
+                key         => '29D662D2',
+                include_src => false,
+                pin         => '300'
+              } ->
+              apt::pin { 'icinga-debmon':
+                packages    => 'icinga*',
+                priority    => '500',
+                order       => '40',
+                origin      => 'debmon.org'
+              }
+            }
           }
         }
       }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -57,44 +57,24 @@ class icinga2::server::install::repos inherits icinga2::server {
       'Debian': {
         include apt
         $icinga2_server_service_name = 'icinga2'
-
-        case $::operatingsystemmajrelease {
-          '7': {
-            #On Debian (7) icinga2 packages are on backports
-            if $use_debmon_repo == false {
-              include apt::backports
-            } else {
-              apt::source { 'debmon':
-                location    => 'http://debmon.org/debmon',
-                release     => "debmon-${lsbdistcodename}",
-                repos       => 'main',
-                key_source  => 'http://debmon.org/debmon/repo.key',
-                key         => '29D662D2',
-                include_src => false,
-                # backports repo use 200
-                pin         => '300'
-              }
+        if $use_debmon_repo == true {
+          apt::source { 'debmon':
+            location    => 'http://debmon.org/debmon',
+            release     => "debmon-${lsbdistcodename}",
+            repos       => 'main',
+            key_source  => 'http://debmon.org/debmon/repo.key',
+            key         => '7E55BD75930BB3674BFD6582DC0EE15A29D662D2',
+            include_src => false
+          }
+          if $::operatingsystemmajrelease == '7' {
+            apt::pin { 'debmon':
+              priority    => '300',
+              origin      => 'debmon.org'
             }
           }
-          '8': {
-            if $use_debmon_repo == true {
-              apt::source { 'debmon':
-                location    => 'http://debmon.org/debmon',
-                release     => "debmon-${lsbdistcodename}",
-                repos       => 'main',
-                key_source  => 'http://debmon.org/debmon/repo.key',
-                key         => '29D662D2',
-                include_src => false,
-                pin         => '300'
-              } ->
-              apt::pin { 'icinga-debmon':
-                packages    => 'icinga*',
-                priority    => '500',
-                order       => '40',
-                origin      => 'debmon.org'
-              }
-            }
-          }
+        }
+        elsif $::operatingsystemmajrelease == '7' {
+          include apt::backports
         }
       }
 


### PR DESCRIPTION
Tested with Debian 7 and Debian 8 and it is working on both.
For Debian 8, packages 'icinga*' from debmon are pinned with priority 500, and default pin priority for debmon repository is 300.
