### PR TITLE
Add Scientific Linux support

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -33,7 +33,7 @@ class icinga2::install::repos inherits icinga2 {
   if $manage_repos == true {
     case $::operatingsystem {
       #CentOS or RedHat systems:
-      'CentOS', 'RedHat': {
+      'CentOS', 'RedHat', 'Scientific': {
         #Add the official Icinga Yum repository: http://packages.icinga.org/epel/
         yumrepo { 'icinga2_yum_repo':
           baseurl  => "http://packages.icinga.org/epel/${::operatingsystemmajrelease}/release/",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,7 @@ class icinga2::params {
   ##################
   # Icinga 2 common package parameters
   case $::operatingsystem {
-    'CentOS', 'RedHat': {
+    'CentOS', 'RedHat', 'Scientific': {
       #Pick the right package provider:
       $package_provider = 'yum'
     }
@@ -59,7 +59,7 @@ class icinga2::params {
   #Pick the right package parameters based on the OS:
   case $::operatingsystem {
     #CentOS systems:
-    'CentOS', 'RedHat': {
+    'CentOS', 'RedHat', 'Scientific': {
       case $::operatingsystemmajrelease {
         '5': {
           #Icinga 2 package:
@@ -148,7 +148,7 @@ class icinga2::params {
 
   case $::operatingsystem {
     #Icinga 2 server daemon names for Red Had/CentOS systems:
-    'CentOS', 'RedHat': {
+    'CentOS', 'RedHat', 'Scientific': {
       case $::operatingsystemmajrelease {
         '5': {
           $icinga2_daemon_name = 'icinga2'
@@ -216,7 +216,7 @@ class icinga2::params {
   #Pick the right package parameters based on the OS:
   case $::operatingsystem {
     #CentOS systems:
-    'CentOS', 'RedHat': {
+    'CentOS', 'RedHat', 'Scientific': {
       case $::operatingsystemmajrelease {
         '5': {
           #Icinga 2 server package
@@ -290,7 +290,7 @@ class icinga2::params {
 
   case $::operatingsystem {
     #CentOS or RedHat systems:
-    'CentOS', 'RedHat': {
+    'CentOS', 'RedHat', 'Scientific': {
       #Settings for /etc/icinga2/:
       $config_owner = 'icinga'
       $config_group = 'icinga'
@@ -335,7 +335,7 @@ class icinga2::params {
 
   case $::operatingsystem {
     #File and template variable names for Red Had/CentOS systems:
-    'CentOS', 'RedHat': {
+    'CentOS', 'RedHat', 'Scientific': {
       $nrpe_config_basedir = '/etc/nagios'
       $nrpe_plugin_libdir  = '/usr/lib64/nagios/plugins'
       $checkplugin_libdir  = '/usr/lib64/nagios/plugins'
@@ -372,7 +372,7 @@ class icinga2::params {
   # Icinga 2 client package parameters
   case $::operatingsystem {
     #CentOS or RedHat systems:
-    'CentOS', 'RedHat': {
+    'CentOS', 'RedHat', 'Scientific': {
       case $::operatingsystemmajrelease {
         '5': {
           #Pick the right list of client packages:
@@ -433,7 +433,7 @@ class icinga2::params {
   # Icinga 2 client service parameters
   case $::operatingsystem {
     #Daemon names for Red Had/CentOS systems:
-    'CentOS', 'RedHat': {
+    'CentOS', 'RedHat', 'Scientific': {
       $nrpe_daemon_name = 'nrpe'
     }
 


### PR DESCRIPTION
This commit simply adds 'Scientific' to the OS support.  The values appear to be the same as they are for RedHat/CentOS
