### PR TITLE
Removing /etc/icinga2/features-available from the directory array

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,7 +34,6 @@ class icinga2::config {
 
   file {
     [
-      '/etc/icinga2/features-available',
       '/etc/icinga2/features-enabled',
       '/etc/icinga2/objects',
     ]:


### PR DESCRIPTION
There is not reason to remove the files. They are installed by package and do not affect the system. Plus The user won't be able to activate a new feature because the conf file will not be there.
