### PR TITLE
Fix for: undefined method `any?' for nil:NilClass

### DIFF
--- a/manifests/object/checkcommand.pp
+++ b/manifests/object/checkcommand.pp
@@ -40,7 +40,7 @@ define icinga2::object::checkcommand (
     validate_string($cmd_path)
     
     validate_hash($env)
-      
+    
     validate_hash($vars)
     if $timeout {
       validate_re($timeout, '^\d+$')

--- a/manifests/object/checkcommand.pp
+++ b/manifests/object/checkcommand.pp
@@ -16,7 +16,7 @@ define icinga2::object::checkcommand (
   $command                               = undef,
   $cmd_path                              = 'PluginDir',
   $arguments                             = {},
-  $env                                   = undef,
+  $env                                   = {},
   $vars                                  = {},
   $timeout                               = undef,
   $target_dir                            = '/etc/icinga2/objects/checkcommands',
@@ -38,9 +38,9 @@ define icinga2::object::checkcommand (
     validate_string($template_to_import)
     validate_array($command)
     validate_string($cmd_path)
-    if $env {
-      validate_hash($env)
-    }
+    
+    validate_hash($env)
+      
     validate_hash($vars)
     if $timeout {
       validate_re($timeout, '^\d+$')


### PR DESCRIPTION
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Failed to parse template icinga2/object_checkcommand.conf.erb:
  Filepath: /etc/puppet/environments/develop/modules/icinga2/templates/object_checkcommand.conf.erb
  Line: 35
  Detail: undefined method `any?' for nil:NilClass
 at /etc/puppet/environments/develop/modules/icinga2/manifests/object/checkcommand.pp:65 on node icinga.creativesandbox.de
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
