### PR TITLE
added missing quotes in command line

### DIFF
--- a/templates/object_checkcommand.conf.erb
+++ b/templates/object_checkcommand.conf.erb
@@ -18,7 +18,7 @@ object CheckCommand "<%= @object_checkcommandname %>" {
 
   <%- end -%>
   <%- if @command -%>
-  command = [ <% if @cmd_path -%><%= @cmd_path -%> + <% end -%><% @command.each_with_index do |cmd, i| %><%= cmd -%><%= ', ' if i < (@command.size - 1) %><% end %> ]
+  command = [ <% if @cmd_path -%><%= @cmd_path -%> + <% end -%><% @command.each_with_index do |cmd, i| %>"<%= cmd -%>"<%= ', ' if i < (@command.size - 1) %><% end %> ]
   <%- end -%>
   <%- if @arguments.any? -%>
 


### PR DESCRIPTION
I get following error on creating a checkcommand:

> critical/config: Error: Error while evaluating expression: Tried to access undefined script variable 'check_nrpe'
> Location:
> /etc/icinga2/objects/checkcommands/check_nrpe.conf(15):   import "plugin-check-command"
> /etc/icinga2/objects/checkcommands/check_nrpe.conf(16):
> /etc/icinga2/objects/checkcommands/check_nrpe.conf(17):   command = [ PluginDir + check_nrpe, check_xyz ]
>                                                                                   ^^^^^^^^^^
> /etc/icinga2/objects/checkcommands/check_nrpe.conf(18):
> /etc/icinga2/objects/checkcommands/check_nrpe.conf(19):   arguments = {
> 
> critical/config: 1 error

Putting _cmd_ in double quotes, and parsing works as expected.
