### PR TITLE
FR: Generic apply_service object

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,13 +509,13 @@ The `accept_config` and `accept_commands` parameters default to **false**.
 
 See the Icinga 2 documention for more info: [http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-apilistener](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-apilistener)
 
-####[`icinga2::object::apply_service_to_host`](id:object_apply_service_to_host)
+####[`icinga2::object::apply_service`](id:object_apply_service)
 
-The `apply_service_to_host` defined type can create `apply` objects to apply services to hosts:
+The `apply_service` defined type can create `apply` objects to apply services to hosts:
 
 <pre>
 #Create an apply that checks the number of zombie processes:
-icinga2::object::apply_service_to_host { 'check_zombie_procs':
+icinga2::object::apply_service { 'check_zombie_procs':
   display_name => 'Zombie procs',
   check_command => 'nrpe',
   vars => {
@@ -527,7 +527,13 @@ icinga2::object::apply_service_to_host { 'check_zombie_procs':
 }
 </pre>
 
-This defined type has the same available parameters that the `icinga2::object::service` defined type does.
+This defined type has the same available parameters that the `icinga2::object::service` defined type does except the apply parameter.
+
+The `apply` allows multiple services with one definition based on host variables. See [http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/monitoring-basics#using-apply-for-custom-attribute-override](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/monitoring-basics#using-apply-for-custom-attribute-override) for more information.
+
+<pre>
+apply => 'for (interface_name => interface_config in host.vars.interfaces)';
+</pre>
 
 The `assign_where` and `ignore_where` parameter values are meant to be provided as strings. Since Icinga 2 requires that string literals be double-quoted, the whole string in your Puppet site manifests will have to be single-quoted (leaving the double quotes intact inside):
 
@@ -1084,7 +1090,7 @@ Objects available:
 * `apply_dependency`
 * `apply_notification_to_host`
 * `apply_notification_to_service`
-* `apply_service_to_host`
+* `apply_service`
 * `checkcommand`
 * `dependency`
 * `eventcommand`

--- a/manifests/object/apply_service.pp
+++ b/manifests/object/apply_service.pp
@@ -1,4 +1,4 @@
-# == Defined type: icinga2::object::apply_service_to_host
+# == Defined type: icinga2::object::apply_service
 #
 # This is a defined type for Icinga 2 apply objects that apply services to hosts.
 # See the following Icinga 2 doc page for more info:
@@ -10,8 +10,9 @@
 # See the inline comments.
 #
 
-define icinga2::object::apply_service_to_host (
+define icinga2::object::apply_service (
   $object_servicename = $name,
+  $apply = 'to Host',
   $template_to_import = 'generic-service',
   $display_name = $name,
   $assign_where = undef,
@@ -62,29 +63,20 @@ define icinga2::object::apply_service_to_host (
 
   #If the refresh_icinga2_service parameter is set to true...
   if $refresh_icinga2_service == true {
-
-    file { "${target_dir}/${target_file_name}":
-      ensure  => $target_file_ensure,
-      owner   => $target_file_owner,
-      group   => $target_file_group,
-      mode    => $target_file_mode,
-      content => template('icinga2/object_apply_service_to_host.conf.erb'),
-      #...notify the Icinga 2 daemon so it can restart and pick up changes made to this config file...
-      notify  => Service['icinga2'],
-    }
-
+    $_notify = Service['icinga2']
   }
   #...otherwise, use the same file resource but without a notify => parameter:
   else {
-
-    file { "${target_dir}/${target_file_name}":
-      ensure  => $target_file_ensure,
-      owner   => $target_file_owner,
-      group   => $target_file_group,
-      mode    => $target_file_mode,
-      content => template('icinga2/object_apply_service_to_host.conf.erb'),
-    }
-
+    $_notify = undef
   }
 
+  file { "${target_dir}/${target_file_name}":
+    ensure  => $target_file_ensure,
+    owner   => $target_file_owner,
+    group   => $target_file_group,
+    mode    => $target_file_mode,
+    content => template('icinga2/object_apply_service.conf.erb'),
+    #...notify the Icinga 2 daemon so it can restart and pick up changes made to this config file...
+    notify  => $_notify,
+  }
 }

--- a/templates/object_apply_service.conf.erb
+++ b/templates/object_apply_service.conf.erb
@@ -10,7 +10,7 @@
  *
  */
 
-apply Service "<%= @object_servicename %>" to Host {
+apply Service "<%= @object_servicename %>" <%= @apply %> {
   <%#- If any of the @ parameters are undefined, don't print anything for them: -%>
   <%- if @template_to_import -%>
   <%#- Otherwise, include the parameter: -%>


### PR DESCRIPTION
Hi,

currently it is impossible to create Service Object apply for like the [documentation](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/monitoring-basics?highlight-search=apply%20Service%20for#using-apply-for-custom-attribute-override) describe it.

I change the static apply_service_to_host manifest to a more generic apply_service manifest. You can do somethink like this right now:

```
icinga2::object::apply_service{ "if-":
  display_name => '"IF-" + interface_name',
  apply => 'for (interface_name => interface_config in host.vars.interfaces)';
}
```

I dont know, If a backward compatibility for object_apply_service_to_host. is required.

Regards,
Jam
