### PR TITLE
fixed regex of interval in object/notification.pp

### DIFF
--- a/manifests/object/notification.pp
+++ b/manifests/object/notification.pp
@@ -45,7 +45,7 @@ define icinga2::object::notification (
   validate_array($user_groups)
   validate_hash($times)
   if $interval {
-    validate_re($interval, '^\d$')
+    validate_re($interval, '^\d+m?$')
   }
   if $period {
     validate_string($period)


### PR DESCRIPTION
now validates:
- number with more than one digit, e.g. 9,25,128,3600
- number with minute, e.g. 2m, 30m, 1440m

Have I missed one value option, that should be checked?
