### PR TITLE
Hotfix notification missing quotes

### DIFF
--- a/manifests/object/notification.pp
+++ b/manifests/object/notification.pp
@@ -45,7 +45,7 @@ define icinga2::object::notification (
   validate_array($user_groups)
   validate_hash($times)
   if $interval {
-    validate_re($interval, '^\d$')
+    validate_re($interval, '^\d+m?$')
   }
   if $period {
     validate_string($period)

--- a/templates/object_notification.conf.erb
+++ b/templates/object_notification.conf.erb
@@ -58,7 +58,7 @@ object Notification "<%= @object_notificationname %>" {
   <%- end -%>
   <%- if @period -%>
 
-  period = <%= @period %>
+  period = "<%= @period %>"
   <%- end -%>
   <%- if @types.empty? !=true -%>
 


### PR DESCRIPTION
fixed regex of interval in object/notification.pp
now validates:
- number with more than one digit, e.g. 9,25,128,3600
- number with minute, e.g. 2m, 30m, 1440m

Hotfix notification missing quotes
- add missing quotes around period value in Notifications

> critical/config: Error: Error while evaluating expression: Tried to access undefined script variable 'workhours'
> Location:
> /etc/icinga2/objects/notifications/critical_service_nonworkhours.conf(21):   interval = 15
> /etc/icinga2/objects/notifications/critical_service_nonworkhours.conf(22): 
> /etc/icinga2/objects/notifications/critical_service_nonworkhours.conf(23):   period = workhours
> /etc/icinga2/objects/notifications/critical_service_nonworkhours.conf(24): 
> /etc/icinga2/objects/notifications/critical_service_nonworkhours.conf(25):   types = [ Problem, Recovery ]
