### PR TITLE
Add parameter to override the main Icinga2 config template.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@
 # Please see the README for details on how to use this module.
 #
 class icinga2 (
+  $config_template              = $::icinga2::params::config_template,
   $default_features             = true,
   $db_type                      = $::icinga2::params::db_type,
   $db_host                      = 'localhost',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class icinga2::params {
 
   #This section has parameters that are used by both the node and server subclasses
 
+  $config_template = 'icinga2/icinga2.conf.erb'
   $manage_service = true
 
   ##################


### PR DESCRIPTION
- This is a simple change that lets users override the main config template to add some flexibility. 
