### PR TITLE
Add parameter to override the main Icinga2 config template.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -46,7 +46,7 @@ class icinga2::config {
 
   file { '/etc/icinga2/icinga2.conf':
     ensure  => file,
-    content => template('icinga2/icinga2.conf.erb'),
+    content => template($::icinga2::config_template),
   }
 
   # maintained object directories

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@
 # Please see the README for details on how to use this module.
 #
 class icinga2 (
+  $config_template              = $::icinga2::params::config_template,
   $default_features             = true,
   $db_type                      = $::icinga2::params::db_type,
   $db_host                      = 'localhost',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class icinga2::params {
 
   #This section has parameters that are used by both the node and server subclasses
 
+  $config_template = 'icinga2/icinga2.conf.erb'
   $manage_service = true
 
   ##################


### PR DESCRIPTION
- This simply adds a parameter to override the default Icinga2 config template to add flexibility.
