### PR TITLE
Make service name order agnostic

### DIFF
--- a/manifests/nrpe/command.pp
+++ b/manifests/nrpe/command.pp
@@ -21,13 +21,15 @@ define icinga2::nrpe::command (
   validate_string($nrpe_plugin_libdir)
   validate_string($nrpe_plugin_name)
 
+  include icinga2::nrpe
+
   file { "/etc/nagios/nrpe.d/${command_name}.cfg":
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
     content => template('icinga2/nrpe_command.cfg.erb'),
-    require => Package[$::icinga2::icinga2_client_packages],
-    notify  => Service[$::icinga2::nrpe_daemon_name],
+    require => Anchor['icinga2::nrpe::packages'],
+    notify  => Service['nrpe'],
   }
 }
 

--- a/manifests/nrpe/install/packages.pp
+++ b/manifests/nrpe/install/packages.pp
@@ -6,5 +6,7 @@ class icinga2::nrpe::install::packages {
     provider        => $::icinga2::package_provider,
     install_options => $::icinga2::client_plugin_package_install_options,
   }
+
+  Package[$::icinga2::icinga2_client_packages] -> anchor { 'icinga2::nrpe::packages': }
 }
 

--- a/manifests/nrpe/plugin.pp
+++ b/manifests/nrpe/plugin.pp
@@ -23,13 +23,15 @@ define icinga2::nrpe::plugin (
   validate_string($name)
   validate_string($nrpe_plugin_libdir)
 
+  include icinga2::nrpe
+
   file { "${nrpe_plugin_libdir}/${plugin_name}":
     owner   => 'root',
     group   => 'root',
     mode    => '0755',
     source  => $source_file,
-    require => Package[$::icinga2::icinga2_client_packages],
-    notify  => Service[$::icinga2::nrpe_daemon_name],
+    require => Anchor['icinga2::nrpe::packages'],
+    notify  => Service['nrpe'],
   }
 }
 

--- a/manifests/nrpe/service.pp
+++ b/manifests/nrpe/service.pp
@@ -5,10 +5,11 @@
 class icinga2::nrpe::service {
   #Service resource for NRPE.
   #This references the daemon name we defined in the icinga2::params class based on the OS:
-  service { $::icinga2::nrpe_daemon_name:
+  service { 'nrpe':
     ensure    => running,
+    name      => $::icinga2::nrpe_daemon_name,
     enable    => true, #Enable the service to start on system boot
-    #require   => Package[$::icinga2::icinga2_client_packages],
+    #require  => Package[$::icinga2::icinga2_client_packages],
     subscribe => Class['::icinga2::nrpe::config'], #Subscribe to the client::config class so the service gets restarted if any config files change
   }
 }

--- a/spec/classes/icinga2_nrpe_spec.rb
+++ b/spec/classes/icinga2_nrpe_spec.rb
@@ -16,7 +16,7 @@ describe 'icinga2::nrpe' do
       it { should contain_class('icinga2::nrpe') }
       it { should contain_class('icinga2::nrpe::service') }
       it { should contain_class('icinga2::params') }
-      it { should contain_service(facts[:nrpe_daemon_name]) }
+      it { should contain_service('nrpe').with(:name => facts[:nrpe_daemon_name]) }
     end
   end
 end


### PR DESCRIPTION
Puppet versions < 4.0 do not resolve correctly scoped variables in some
cases. It is a lot more order dependent. To avoid that, this commit uses
a service with a static title and a dynamic name => attribute.

For the packages, as the title is an array, it is not possible to use a
name => attribute. To have a static resource I have then chosen to use
an anchor, which is dependent on the packages.
