### PR TITLE
tests: an alternative to the includes

### DIFF
--- a/manifests/nrpe/command.pp
+++ b/manifests/nrpe/command.pp
@@ -21,8 +21,6 @@ define icinga2::nrpe::command (
   validate_string($nrpe_plugin_libdir)
   validate_string($nrpe_plugin_name)
 
-  include icinga2::nrpe
-
   file { "/etc/nagios/nrpe.d/${command_name}.cfg":
     owner   => 'root',
     group   => 'root',

--- a/manifests/nrpe/plugin.pp
+++ b/manifests/nrpe/plugin.pp
@@ -23,8 +23,6 @@ define icinga2::nrpe::plugin (
   validate_string($name)
   validate_string($nrpe_plugin_libdir)
 
-  include icinga2::nrpe
-
   file { "${nrpe_plugin_libdir}/${plugin_name}":
     owner   => 'root',
     group   => 'root',

--- a/spec/defines/icinga2_nrpe_command_spec.rb
+++ b/spec/defines/icinga2_nrpe_command_spec.rb
@@ -8,6 +8,12 @@ describe 'icinga2::nrpe::command', :type => :define do
         facts
       end
 
+      let :pre_condition do
+        "class {
+          '::icinga2::nrpe':
+        }"
+      end
+
       let (:title) { '_COMMAND_' }
       let (:params) { { } }
 
@@ -24,6 +30,12 @@ describe 'icinga2::nrpe::command', :type => :define do
     context "on #{name} with parameter: nrpe_plugin_args" do
       let :facts do
         facts
+      end
+
+      let :pre_condition do
+        "class {
+          '::icinga2::nrpe':
+        }"
       end
 
       let (:title) { '_COMMAND_' }
@@ -47,6 +59,12 @@ describe 'icinga2::nrpe::command', :type => :define do
         facts
       end
 
+      let :pre_condition do
+        "class {
+          '::icinga2::nrpe':
+        }"
+      end
+
       let (:title) { '_COMMAND_' }
 
       let (:params) {
@@ -66,6 +84,12 @@ describe 'icinga2::nrpe::command', :type => :define do
     context "on #{name} with parameter: nrpe_plugin_name" do
       let :facts do
         facts
+      end
+
+      let :pre_condition do
+        "class {
+          '::icinga2::nrpe':
+        }"
       end
 
       let (:title) { '_COMMAND_' }

--- a/spec/defines/icinga2_nrpe_plugin_spec.rb
+++ b/spec/defines/icinga2_nrpe_plugin_spec.rb
@@ -14,6 +14,12 @@ describe 'icinga2::nrpe::plugin', :type => :define do
         facts
       end
 
+      let :pre_condition do
+        "class {
+          '::icinga2::nrpe':
+        }"
+      end
+
       let (:title) { '_COMMAND_' }
 
       let (:params) {
@@ -34,6 +40,12 @@ describe 'icinga2::nrpe::plugin', :type => :define do
         facts
       end
 
+      let :pre_condition do
+        "class {
+          '::icinga2::nrpe':
+        }"
+      end
+
       let (:title) { '_COMMAND_' }
 
       let (:params) {
@@ -52,6 +64,12 @@ describe 'icinga2::nrpe::plugin', :type => :define do
     context "on #{name} with parameter: source_file" do
       let :facts do
         facts
+      end
+
+      let :pre_condition do
+        "class {
+          '::icinga2::nrpe':
+        }"
       end
 
       let (:title) { '_COMMAND_' }


### PR DESCRIPTION
Instead of putting includes in the icinga2::nrpe::command and
icinga2::nrpe::plugin, it is also possible to set them as prerequisites
in the spec tests.

This is an alternative approach to GH-126.
