### PR TITLE
Prepare Feature #9150

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "operatingsystem_support": [
     {
       "operatingsystem": "CentOS",
-      "operatingsystemmajrelease": [
+      "operatingsystemrelease": [
         "5",
         "6",
         "7"
@@ -18,7 +18,7 @@
     },
     {
       "operatingsystem": "RedHat",
-      "operatingsystemmajrelease": [
+      "operatingsystemrelease": [
         "5",
         "6",
         "7"
@@ -26,14 +26,14 @@
     },
     {
       "operatingsystem": "Debian",
-      "operatingsystemmajrelease": [
+      "operatingsystemrelease": [
         "7",
         "8"
       ]
     },
     {
       "operatingsystem": "RedHat",
-      "operatingsystemmajrelease": [
+      "operatingsystemrelease": [
         "5",
         "6",
         "7"
@@ -41,7 +41,7 @@
     },
     {
       "operatingsystem": "Ubuntu",
-      "operatingsystemmajrelease": [
+      "operatingsystemrelease": [
         "12.04",
         "14.04"
       ]


### PR DESCRIPTION
Hi,
i think this commit should help you to push this module to puppet forge.

"operatingsystemmajrelease" is not supported by puppet forge, take a look into 
https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#operating-system-compatibility-in-metadatajson

Greetings Reamer
