### PR TITLE
Fixing require path

### DIFF
--- a/lib/puppet/parser/functions/icinga2_config_value.rb
+++ b/lib/puppet/parser/functions/icinga2_config_value.rb
@@ -1,4 +1,4 @@
-require "puppet/icinga2/utils"
+require File.join(File.dirname(__FILE__), '../..', 'icinga2/utils.rb')
 
 module Puppet::Parser::Functions
   newfunction(:icinga2_config_value, :type => :rvalue) do |args|


### PR DESCRIPTION
I've experienced the issue that the generation of host objects with vars does not work but produces an error that a file is not found (For more details see http://stackoverflow.com/questions/31973553/puppet-template-does-not-find-module-function) 

After some time debugging and searching around I found this [blogpost](http://jcg.wtf/blog/2011/03/calling-custom-functions-from-other-custom-functions-in-puppet/) and another similar [PR](https://github.com/jenkinsci/puppet-jenkins/pull/347/files).

I don't really know if this is the correct way to fix this issue but it works in my environment (puppet 4.2.1 with a puppetserver)
