### PR TITLE
Update more object define types to be consistent.

### DIFF
--- a/manifests/feature/ido_mysql.pp
+++ b/manifests/feature/ido_mysql.pp
@@ -51,7 +51,8 @@ class icinga2::feature::ido_mysql (
     enable_ha            => $enable_ha,
     cleanup              => $cleanup,
     categories           => $categories,
-    target_file          => '/etc/icinga2/features-available/ido-mysql.conf',
+    target_file_name     => 'ido-mysql.conf',
+    target_dir           => '/etc/icinga2/features-available',
   } ->
 
   ::icinga2::feature { 'ido-mysql':

--- a/manifests/feature/ido_pgsql.pp
+++ b/manifests/feature/ido_pgsql.pp
@@ -51,7 +51,8 @@ class icinga2::feature::ido_pgsql (
     enable_ha            => $enable_ha,
     cleanup              => $cleanup,
     categories           => $categories,
-    target_file          => '/etc/icinga2/features-available/ido-pgsql.conf',
+    target_file_name     => 'ido-pgsql.conf',
+    target_dir           => '/etc/icinga2/features-available',
   } ->
 
   ::icinga2::feature { 'ido-pgsql':

--- a/manifests/object/apply_dependency.pp
+++ b/manifests/object/apply_dependency.pp
@@ -23,7 +23,7 @@ define icinga2::object::apply_dependency (
   $states                = [],
   $assign_where          = undef,
   $ignore_where          = undef,
-  $target_dir            = '/etc/icinga2/conf.d',
+  $target_dir            = '/etc/icinga2/objects/applys',
   $target_file_name      = "${name}.conf",
   $target_file_ensure    = file,
   $target_file_owner     = 'root',

--- a/manifests/object/apply_service.pp
+++ b/manifests/object/apply_service.pp
@@ -40,7 +40,7 @@ define icinga2::object::apply_service (
   $action_url = undef,
   $icon_image = undef,
   $icon_image_alt = undef,
-  $target_dir         = '/etc/icinga2/conf.d',
+  $target_dir         = '/etc/icinga2/objects/applys',
   $target_file_name   = "${name}.conf",
   $target_file_ensure = file,
   $target_file_owner  = 'root',

--- a/manifests/object/dependency.pp
+++ b/manifests/object/dependency.pp
@@ -20,7 +20,7 @@ define icinga2::object::dependency (
   $disable_notifications = undef,
   $period                = undef,
   $states                = [],
-  $target_dir            = '/etc/icinga2/conf.d',
+  $target_dir            = '/etc/icinga2/objects/dependencies',
   $target_file_name      = "${name}.conf",
   $target_file_ensure    = file,
   $target_file_owner     = 'root',

--- a/manifests/object/idomysqlconnection.pp
+++ b/manifests/object/idomysqlconnection.pp
@@ -32,7 +32,7 @@ define icinga2::object::idomysqlconnection (
   },
   $categories      = [],
   $target_file_name     = "${name}.conf",
-  $target_dir           = '/etc/icinga2/objects/idomysqlconnection',
+  $target_dir           = '/etc/icinga2/objects/idomysqlconnections',
   $refresh_service      = $::icinga2::manage_service,
 ) {
 

--- a/manifests/object/idomysqlconnection.pp
+++ b/manifests/object/idomysqlconnection.pp
@@ -31,8 +31,9 @@ define icinga2::object::idomysqlconnection (
     systemcommands_age             => 0,
   },
   $categories      = [],
-  $target_file     = "/etc/icinga2/conf.d/${name}.conf",
-  $refresh_service = $::icinga2::manage_service,
+  $target_file_name     = "${name}.conf",
+  $target_dir           = '/etc/icinga2/objects/idomysqlconnection',
+  $refresh_service      = $::icinga2::manage_service,
 ) {
 
   if ! defined(Class['icinga2']) {
@@ -49,13 +50,12 @@ define icinga2::object::idomysqlconnection (
   validate_bool($enable_ha)
   validate_hash($cleanup)
   validate_array($categories)
-  validate_absolute_path($target_file)
+  validate_absolute_path($target_dir)
   validate_bool($refresh_service)
 
   Class['icinga2::config'] ->
-  file { "icinga2 object idomysqlconnection ${title}":
+  file { "${target_dir}/${target_file_name}":
     ensure  => file,
-    path    => $target_file,
     owner   => $::icinga2::config_owner,
     group   => $::icinga2::config_group,
     mode    => $::icinga2::config_mode,
@@ -63,7 +63,7 @@ define icinga2::object::idomysqlconnection (
   }
 
   if $refresh_service == true {
-    File["icinga2 object idomysqlconnection ${title}"] ~> Class['icinga2::service']
+    File["${target_dir}/${target_file_name}"] ~> Class['icinga2::service']
   }
 
 }

--- a/manifests/object/idopgsqlconnection.pp
+++ b/manifests/object/idopgsqlconnection.pp
@@ -30,9 +30,10 @@ define icinga2::object::idopgsqlconnection (
     servicechecks_age              => 0,
     systemcommands_age             => 0,
   },
-  $categories      = [],
-  $target_file     = "/etc/icinga2/conf.d/${name}.conf",
-  $refresh_service = $::icinga2::manage_service,
+  $categories           = [],
+  $target_file_name     = "${name}.conf",
+  $target_dir           = '/etc/icinga2/objects/idopgsqlconnection',
+  $refresh_service      = $::icinga2::manage_service,
 ) {
 
   if ! defined(Class['icinga2']) {
@@ -49,13 +50,12 @@ define icinga2::object::idopgsqlconnection (
   validate_bool($enable_ha)
   validate_hash($cleanup)
   validate_array($categories)
-  validate_absolute_path($target_file)
+  validate_absolute_path($target_dir)
   validate_bool($refresh_service)
 
   Class['icinga2::config'] ->
-  file { "icinga2 object idopgsqlconnection ${title}":
+  file { "${target_dir}/${target_file_name}":
     ensure  => file,
-    path    => $target_file,
     owner   => $::icinga2::config_owner,
     group   => $::icinga2::config_group,
     mode    => $::icinga2::config_mode,
@@ -63,7 +63,7 @@ define icinga2::object::idopgsqlconnection (
   }
 
   if $refresh_service == true {
-    File["icinga2 object idopgsqlconnection ${title}"] ~> Class['icinga2::service']
+    File["${target_dir}/${target_file_name}"] ~> Class['icinga2::service']
   }
 
 }

--- a/manifests/object/idopgsqlconnection.pp
+++ b/manifests/object/idopgsqlconnection.pp
@@ -32,7 +32,7 @@ define icinga2::object::idopgsqlconnection (
   },
   $categories           = [],
   $target_file_name     = "${name}.conf",
-  $target_dir           = '/etc/icinga2/objects/idopgsqlconnection',
+  $target_dir           = '/etc/icinga2/objects/idopgsqlconnections',
   $refresh_service      = $::icinga2::manage_service,
 ) {
 

--- a/manifests/object/service.pp
+++ b/manifests/object/service.pp
@@ -36,7 +36,7 @@ define icinga2::object::service (
   $action_url = undef,
   $icon_image = undef,
   $icon_image_alt = undef,
-  $target_dir         = '/etc/icinga2/objects/service',
+  $target_dir         = '/etc/icinga2/objects/services',
   $target_file_name   = "${name}.conf",
   $target_file_ensure = file,
   $target_file_owner  = 'root',

--- a/manifests/object/service.pp
+++ b/manifests/object/service.pp
@@ -36,7 +36,7 @@ define icinga2::object::service (
   $action_url = undef,
   $icon_image = undef,
   $icon_image_alt = undef,
-  $target_dir         = '/etc/icinga2/conf.d',
+  $target_dir         = '/etc/icinga2/objects/service',
   $target_file_name   = "${name}.conf",
   $target_file_ensure = file,
   $target_file_owner  = 'root',

--- a/spec/classes/icinga2_feature_ido_mysql_spec.rb
+++ b/spec/classes/icinga2_feature_ido_mysql_spec.rb
@@ -17,12 +17,11 @@ describe 'icinga2::feature::ido_mysql' do
     it { should contain_class('icinga2::feature::ido_mysql') }
     it { should contain_icinga2__feature('ido-mysql') }
     it { should contain_icinga2__object__idomysqlconnection('ido-mysql') }
-    it { should contain_file('icinga2 object idomysqlconnection ido-mysql').with({
-      :path    => '/etc/icinga2/features-available/ido-mysql.conf',
+    it { should contain_file('/etc/icinga2/features-available/ido-mysql.conf').with({
       :content => /database = "icinga2_data"/,
     })}
-    it { should contain_file('icinga2 object idomysqlconnection ido-mysql').without_content(/port =/) }
-    it { should contain_file('icinga2 feature ido-mysql enabled') }
+    it { should contain_file('/etc/icinga2/features-available/ido-mysql.conf').without_content(/port =/) }
+    it { should contain_file('/etc/icinga2/features-available/ido-mysql.conf') }
   end
 
   context "on #{default} with changed parameters" do
@@ -38,8 +37,7 @@ describe 'icinga2::feature::ido_mysql' do
     it { should contain_class('icinga2::feature::ido_mysql') }
     it { should contain_icinga2__feature('ido-mysql') }
     it { should contain_icinga2__object__idomysqlconnection('ido-mysql') }
-    it { should contain_file('icinga2 object idomysqlconnection ido-mysql').with({
-      :path    => '/etc/icinga2/features-available/ido-mysql.conf',
+    it { should contain_file('/etc/icinga2/features-available/ido-mysql.conf').with({
       :content => /database = "foobar"/,
     })}
   end

--- a/spec/classes/icinga2_feature_ido_pgsql_spec.rb
+++ b/spec/classes/icinga2_feature_ido_pgsql_spec.rb
@@ -17,12 +17,12 @@ describe 'icinga2::feature::ido_pgsql' do
     it { should contain_class('icinga2::feature::ido_pgsql') }
     it { should contain_icinga2__feature('ido-pgsql') }
     it { should contain_icinga2__object__idopgsqlconnection('ido-pgsql') }
-    it { should contain_file('icinga2 object idopgsqlconnection ido-pgsql').with({
+    it { should contain_file('/etc/icinga2/features-available/ido-pgsql.conf').with({
       :path    => '/etc/icinga2/features-available/ido-pgsql.conf',
       :content => /database = "icinga2_data"/,
     })}
-    it { should contain_file('icinga2 object idopgsqlconnection ido-pgsql').without_content(/port =/) }
-    it { should contain_file('icinga2 feature ido-pgsql enabled') }
+    it { should contain_file('/etc/icinga2/features-available/ido-pgsql.conf').without_content(/port =/) }
+    it { should contain_file('/etc/icinga2/features-available/ido-pgsql.conf') }
   end
 
   context "on #{default} with changed parameters" do
@@ -38,7 +38,7 @@ describe 'icinga2::feature::ido_pgsql' do
     it { should contain_class('icinga2::feature::ido_pgsql') }
     it { should contain_icinga2__feature('ido-pgsql') }
     it { should contain_icinga2__object__idopgsqlconnection('ido-pgsql') }
-    it { should contain_file('icinga2 object idopgsqlconnection ido-pgsql').with({
+    it { should contain_file('/etc/icinga2/features-available/ido-pgsql.conf').with({
       :path    => '/etc/icinga2/features-available/ido-pgsql.conf',
       :content => /database = "foobar"/,
     })}


### PR DESCRIPTION
- This is a follow up to a PR I made a couple weeks ago which just makes sure the other define types default to being created under the appropriate directories.
- It also updates the tests for the ido objects and changes the titles of some file resources so they're consistent with the other define types.
