### PR TITLE
Add option to check config before icinga restart

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -236,6 +236,8 @@ class icinga2::params {
       $etc_icinga2_obejcts_sub_dir_owner = 'root'
       $etc_icinga2_obejcts_sub_dir_group = 'root'
       $etc_icinga2_obejcts_sub_dir_mode  = '0755'
+      #Settings for service restart
+      $service_restart = '/etc/init.d/icinga2 checkconfig && /etc/init.d/icinga2 restart'
     }
 
     #Fail if we're on any other OS:
@@ -244,7 +246,9 @@ class icinga2::params {
   
   #Whether to purge object files or directories in /etc/icinga2/objects that aren't managed by Puppet
   $purge_unmanaged_object_files = false
-
+  
+  #Wheter to check config before service restart
+  $configtest_enable = false
   ##################
   # Icinga 2 server service settings
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -26,7 +26,9 @@ class icinga2::server (
   $install_mail_utils_package = $icinga2::params::install_mail_utils_package,
   $server_enabled_features = $icinga2::params::server_enabled_features,
   $server_disabled_features = $icinga2::params::server_disabled_features,
-  $purge_unmanaged_object_files = $icinga2::params::purge_unmanaged_object_files
+  $purge_unmanaged_object_files = $icinga2::params::purge_unmanaged_object_files,
+  $configtest_enable = $icinga2::params::configtest_enable,
+  $service_restart = $icinga2::params::service_restart,
 ) inherits icinga2::params {
 
   #Do some validation of parameters so we know we have the right data types:

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -14,7 +14,7 @@
 class icinga2::server::service (
   $configtest_enable = $::icinga2::server::configtest_enable,
   $service_restart   = $::icinga2::server::service_restart,
-) inherits icinga2::server {
+){
 
   include icinga2::server
 

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -11,7 +11,10 @@
 # Coming soon...
 #
 
-class icinga2::server::service inherits icinga2::server {
+class icinga2::server::service (
+  $configtest_enable = $::icinga2::server::configtest_enable,
+  $service_restart   = $::icinga2::server::service_restart,
+) inherits icinga2::server {
 
   include icinga2::server
 
@@ -19,6 +22,12 @@ class icinga2::server::service inherits icinga2::server {
   service {$icinga2::params::icinga2_server_service_name:
     ensure    => running,
     subscribe => [ Class['icinga2::server::config'], Class['icinga2::server::features'] ],
+  }
+
+  if $configtest_enable == true {
+    Service['icinga2'] {
+      restart => $service_restart,
+    }
   }
 
 }


### PR DESCRIPTION
If the configuration contains errors the icinga service will not restart
any more. The option configtest_enable allows to first test the
configuration and only restart the service if the configuration does not
contain any errors.
This prevents icinga from not starting anymore.
