### PR TITLE
Adding hash support for vars values in object::apply_service_to_host

### DIFF
--- a/templates/object_apply_service_to_host.conf.erb
+++ b/templates/object_apply_service_to_host.conf.erb
@@ -36,7 +36,15 @@ apply Service "<%= @object_servicename %>" to Host {
   <%- end -%>
   <%- if @vars.empty? != true  -%>
   <%- @vars.sort_by {|key, value| key}.each do |key, value| -%>
-  vars.<%= key %> = "<%= value %>"
+  <%- if value.is_a?(Hash) -%>
+  vars.<%= key %> = {
+  <%- value.each_pair do |subkey,subvalue|-%>
+    <%= subkey %> = <%= subvalue %>
+  <%- end -%>
+  }
+  <%- else -%>
+  vars.<%= key %> = <%= value %>
+  <%- end -%>
   <%- end -%>
   <%- end -%>
   <%- if @max_check_attempts -%>


### PR DESCRIPTION
The value of the vars variable can be a hash itself. Therefore we need to check for a hash and iterate over that hash and print the subkeys and subvalues. 

This PR is similar to https://github.com/Icinga/puppet-icinga2/pull/58
