### PR TITLE
opentsdb feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -989,6 +989,23 @@ icinga2::object::graphitewriter { 'graphite_relay':
 }
 ````
 
+####[`icinga2::object::opentsdbwriter`](id:object_opentsdbwriter)
+
+This defined type creates an **OpenTsdbWriter** object
+
+Though you can create the file anywhere and with any name via the target_dir and file_name parameters, you should set the target_dir parameter to /etc/icinga2/features-enabled, as that's where Icinga 2 will look for opentsdbwriter connection objects by default.
+
+Example Usage:
+
+````
+icinga2::object::opentsdbwriter { 'opentsdb_server':
+  target_dir => '/etc/icinga2/features-enabled',
+  file_name  => 'opentsdb.conf',
+  host       => '127.0.0.1',
+  port       => 4242,
+}
+````
+
 ####[`icinga2::object::zone`](id:object_zone)
 
 This defined type creates a **Zone** object
@@ -1062,6 +1079,7 @@ Objects available:
 * `idopgsqlconnection`
 * `notificationcommand`
 * `notification`
+* `opentsdbwriter`
 * `perfdatawriter`
 * `scheduleddowntime`
 * `servicegroup`

--- a/manifests/feature/opentsdb.pp
+++ b/manifests/feature/opentsdb.pp
@@ -1,0 +1,17 @@
+# == Class: icinga2::feature::opentsdb
+#
+# Manage and enable opentsdb of Icinga2
+#
+class icinga2::feature::opentsdb (
+  $host = '127.0.0.1',
+  $port = 4242,
+) {
+
+  ::icinga2::object::opentsdbwriter { 'opentsdb':
+    host => $host,
+    port => $port,
+  }
+  ::icinga2::feature { 'opentsdb':
+    manage_file => false
+  }
+}

--- a/manifests/object/opentsdbwriter.pp
+++ b/manifests/object/opentsdbwriter.pp
@@ -1,0 +1,33 @@
+# == Defined type: icinga2::object::opentsdbwriter
+#
+#  This is a defined type for Icinga 2 OpenTsdbWriter objects.
+# See the following Icinga 2 doc page for more info:
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-opentsdbwriter
+#
+# === Parameters
+#
+# See the inline comments.
+#
+
+define icinga2::object::opentsdbwriter (
+  $host       = '127.0.0.1',
+  $port       = 4242,
+  # Put the object files this defined type generates in features-available
+  # since the Graphite writer feature is one that has to be explicitly enabled.
+  $target_dir = '/etc/icinga2/features-available',
+  $file_name  = "${name}.conf",
+) {
+  # Do some validation
+  validate_string($host)
+
+  file { "${target_dir}/${file_name}":
+    ensure  => file,
+    owner   => $::icinga2::config_owner,
+    group   => $::icinga2::config_group,
+    mode    => $::icinga2::config_mode,
+    content => template('icinga2/object/opentsdbwriter.conf.erb'),
+  }
+  if $::icinga2::manage_service {
+    File["${target_dir}/${file_name}"] ~> Class['::icinga2::service']
+  }
+}

--- a/spec/defines/icinga2_object_opentsdbwriter_spec.rb
+++ b/spec/defines/icinga2_object_opentsdbwriter_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+require 'variants'
+
+describe 'icinga2::object::opentsdbwriter', :type => :define do
+  IcingaPuppet.variants.each do |name, facts|
+    context "on #{name} with basic parameters" do
+      let :facts do
+        facts
+      end
+      let :pre_condition do
+        " include 'icinga2'"
+      end
+
+      let(:title) { 'opentsdbtestserver' }
+
+      object_file = '/etc/icinga2/features-available/opentsdbtestserver.conf'
+      it { should contain_icinga2__object__opentsdbwriter('opentsdbtestserver') }
+      it { should contain_file(object_file).with({
+            :ensure => 'file',
+            :path => '/etc/icinga2/features-available/opentsdbtestserver.conf',
+            :content => /object OpenTsdbWriter "opentsdbtestserver"/,
+          }) }
+      it { should contain_file(object_file).with_content(/^\s*host = "127.0.0.1"$/) }
+      it { should contain_file(object_file).with_content(/^\s*port = 4242$/) }
+
+    end
+    context "on #{name} with non basic parameters" do
+      let :facts do
+        facts
+      end
+      let :params do
+      {
+        :host => 'www.icinga.org',
+        :port => '1234',
+      }
+      end
+      let :pre_condition do
+        " include 'icinga2'"
+      end
+
+      let(:title) { 'opentsdbtest2server' }
+
+      object_file = '/etc/icinga2/features-available/opentsdbtest2server.conf'
+      it { should contain_icinga2__object__opentsdbwriter('opentsdbtest2server') }
+      it { should contain_file(object_file).with({
+            :ensure => 'file',
+            :path => '/etc/icinga2/features-available/opentsdbtest2server.conf',
+            :content => /object OpenTsdbWriter "opentsdbtest2server"/,
+          }) }
+      it { should contain_file(object_file).with_content(/^\s*host = "www.icinga.org"$/) }
+      it { should contain_file(object_file).with_content(/^\s*port = 1234$/) }
+    end
+  end
+end

--- a/templates/object/opentsdbwriter.conf.erb
+++ b/templates/object/opentsdbwriter.conf.erb
@@ -1,0 +1,13 @@
+<%= ERB.new(File.read(File.expand_path('_header.erb',File.dirname(File.dirname(file))))).result(binding) -%>
+
+/**
+ * The OpenTsdbWriter type writes check result metrics and
+ * performance data to a OpenTSDB tcp socket.
+ */
+
+library "perfdata"
+
+object OpenTsdbWriter "<%= @name -%>" {
+  host = "<%= @host -%>"
+  port = <%= @port %>
+}


### PR DESCRIPTION
Hi,

that's a default disabled feature after rpm installation. The opentsdb implementation is a class , so we have maximum one interface. At the moment i see no need for more.

 If the maintainer of this puppet module prefer a define, i can write it.

Greetings Reamer
