### PR TITLE
Debug Feature

### DIFF
--- a/manifests/feature/debuglog.pp
+++ b/manifests/feature/debuglog.pp
@@ -1,0 +1,16 @@
+# == Class: icinga2::feature::debuglog
+#
+# Manage and enable the debug log of Icinga2
+#
+class icinga2::feature::debuglog (
+  $severity = 'debug',
+  $path     = '/var/log/icinga2/debug.log'
+) {
+
+  validate_string($severity)
+  validate_absolute_path($path)
+
+  ::icinga2::feature { 'debuglog':
+    content => template('icinga2/feature/debuglog.conf.erb'),
+  }
+}

--- a/templates/feature/debuglog.conf.erb
+++ b/templates/feature/debuglog.conf.erb
@@ -1,0 +1,6 @@
+<%= ERB.new(File.read(File.expand_path('_header.erb',File.dirname(File.dirname(file))))).result(binding) -%>
+
+object FileLogger "debug-file" {
+  severity = "<%= @severity %>"
+  path = "<%= @path %>"
+}


### PR DESCRIPTION
Hi,

that's a default disabled feature after rpm installation. I know that the debug feature is nearly the same like the mainlog feature.

If the maintainer of this puppet module prefer a define for object FileLogger, i can write it.

Greetings Reamer
