### PR TITLE
gelf feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -989,6 +989,23 @@ icinga2::object::graphitewriter { 'graphite_relay':
 }
 ````
 
+####[`icinga2::object::gelfwriter`](id:object_gelfwriter)
+
+This defined type creates an **GelfWriter** object
+
+Though you can create the file anywhere and with any name via the target_dir and file_name parameters, you should set the target_dir parameter to /etc/icinga2/features-enabled, as that's where Icinga 2 will look for gelfwriter connection objects by default.
+
+Example Usage:
+
+````
+icinga2::object::gelfwriter { 'gelf_server':
+  target_dir => '/etc/icinga2/features-enabled',
+  file_name  => 'gelf.conf',
+  host       => '127.0.0.1',
+  port       => 12201,
+}
+````
+
 ####[`icinga2::object::zone`](id:object_zone)
 
 This defined type creates a **Zone** object
@@ -1056,6 +1073,7 @@ Objects available:
 * `dependency`
 * `eventcommand`
 * `graphitewriter`
+* `gelfwriter`
 * `hostgroup`
 * `host`
 * `idomysqlconnection`

--- a/manifests/feature/gelf.pp
+++ b/manifests/feature/gelf.pp
@@ -1,0 +1,19 @@
+# == Class: icinga2::feature::gelf
+#
+# Manage and enable gelf of Icinga2
+#
+class icinga2::feature::gelf (
+  $host   = '127.0.0.1',
+  $port   = 12201,
+  $source = undef,
+) {
+
+  ::icinga2::object::gelfwriter { 'gelf':
+    host   => $host,
+    port   => $port,
+    source => $source,
+  }
+  ::icinga2::feature { 'gelf':
+    manage_file => false,
+  }
+}

--- a/manifests/object/gelfwriter.pp
+++ b/manifests/object/gelfwriter.pp
@@ -1,0 +1,38 @@
+# == Defined type: icinga2::object::gelfwriter
+#
+# This is a defined type for Icinga 2 GelfWriter objects.
+# See the following Icinga 2 doc page for more info:
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-gelfwriter
+#
+# === Parameters
+#
+# See the inline comments.
+#
+
+define icinga2::object::gelfwriter (
+  $host       = '127.0.0.1',
+  $port       = 12201,
+  $source     = undef,
+  # Put the object files this defined type generates in features-available
+  # since the Gelf writer feature is one that has to be explicitly enabled.
+  $target_dir = '/etc/icinga2/features-available',
+  $file_name  = "${name}.conf",
+) {
+  # Do some validation
+  validate_string($host)
+
+  if $source {
+    validate_string($source)
+  }
+
+  file { "${target_dir}/${file_name}":
+    ensure  => file,
+    owner   => $::icinga2::config_owner,
+    group   => $::icinga2::config_group,
+    mode    => $::icinga2::config_mode,
+    content => template('icinga2/object/gelfwriter.conf.erb'),
+  }
+  if $::icinga2::manage_service {
+    File["${target_dir}/${file_name}"] ~> Class['::icinga2::service']
+  }
+}

--- a/spec/defines/icinga2_object_gelfwriter_spec.rb
+++ b/spec/defines/icinga2_object_gelfwriter_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+require 'variants'
+
+describe 'icinga2::object::gelfwriter', :type => :define do
+  IcingaPuppet.variants.each do |name, facts|
+    context "on #{name} with basic parameters" do
+      let :facts do
+        facts
+      end
+      let :pre_condition do
+        " include 'icinga2'"
+      end
+
+      let(:title) { 'gelftestserver' }
+
+      object_file = '/etc/icinga2/features-available/gelftestserver.conf'
+      it { should contain_icinga2__object__gelfwriter('gelftestserver') }
+      it { should contain_file(object_file).with({
+            :ensure => 'file',
+            :path => '/etc/icinga2/features-available/gelftestserver.conf',
+            :content => /object GelfWriter "gelftestserver"/,
+          }) }
+      it { should contain_file(object_file).with_content(/^\s*host = "127.0.0.1"$/) }
+      it { should contain_file(object_file).with_content(/^\s*port = 12201$/) }
+      it { should_not contain_file(object_file).with_content(/^\s*source/) }
+
+    end
+    context "on #{name} with basic parameters and source" do
+      let :facts do
+        facts
+      end
+      let :params do
+      {
+        :source => 'icinga2gelf',
+      }
+      end
+      let :pre_condition do
+        "include 'icinga2'"
+      end
+
+      let(:title) { 'gelftestserver' }
+
+      object_file = '/etc/icinga2/features-available/gelftestserver.conf'
+      it { should contain_icinga2__object__gelfwriter('gelftestserver') }
+      it { should contain_file(object_file).with({
+            :ensure => 'file',
+            :path => '/etc/icinga2/features-available/gelftestserver.conf',
+            :content => /object GelfWriter "gelftestserver"/,
+          }) }
+      it { should contain_file(object_file).with_content(/^\s*host = "127.0.0.1"$/) }
+      it { should contain_file(object_file).with_content(/^\s*port = 12201$/) }
+      it { should contain_file(object_file).with_content(/^\s*source = "icinga2gelf"$/) }
+
+    end
+  end
+end

--- a/templates/object/gelfwriter.conf.erb
+++ b/templates/object/gelfwriter.conf.erb
@@ -1,0 +1,15 @@
+/**
+ * The GelfWriter type writes event log entries
+ * to a GELF tcp socket provided by graylog2,
+ * logstash or any other receiver.
+ */
+
+library "perfdata"
+
+object GelfWriter "<%= @name -%>" {
+  host = "<%= @host -%>"
+  port = <%= @port %>
+  <%- if @source -%>
+  source = "<%= @source -%>"
+  <%- end -%>
+}


### PR DESCRIPTION
Hi,

that's a default disabled feature after rpm installation. The gelf implementation is a class , so we have maximum one interface to an gelf service. At the moment i see no need for more.

If the maintainer of this puppet module prefer a define, i can write it.

Greetings Reamer
