### PR TITLE
Refactor repository handling

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,11 +71,10 @@ class icinga2 (
   validate_string($icinga2_package)
   validate_bool($install_nagios_plugins)
 
-  if $manage_repos != false {
-    include "::icinga2::repo::${package_provider}"
-    Class["::icinga2::repo::${package_provider}"] ->
-    Class['::icinga2::install']
+  if $manage_repos == true {
+    include icinga2::repo
   }
+
   anchor {'icinga2::start':} ->
   class {'::icinga2::install':} ~>
   class {'::icinga2::config':} ~>

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,0 +1,22 @@
+# == Class: icinga2::repo
+#
+# Manages the repository handling for the platforms that support it.  By
+# default we notiofy the user of unsupported platforms.
+#
+class icinga2::repo {
+  include icinga2
+
+  case $::osfamily {
+    'Debian': {
+      include icinga2::repo::apt
+      Class['icinga2::repo::apt'] -> Class['icinga2::install']
+    }
+    'RedHat': {
+      include icinga2::repo::yum
+      Class['icinga2::repo::yum'] -> Class['icinga2::install']
+    }
+    default: {
+      notify { "Class[icinga2::repo] does not support ${::osfamily}": }
+    }
+  }
+}

--- a/spec/classes/icinga2_repo_spec.rb
+++ b/spec/classes/icinga2_repo_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'variants'
+
+describe 'icinga2::repo' do
+
+  context "on Debian" do
+    let :facts do
+      IcingaPuppet.variants['Debian wheezy']
+    end
+    it { should contain_class('icinga2::repo::apt') }
+  end
+
+  context "on RedHat" do
+    let :facts do
+      IcingaPuppet.variants['RedHat 6']
+    end
+    it { should contain_class('icinga2::repo::yum') }
+  end
+end


### PR DESCRIPTION
This work pushes the logic of how to handle repositories into a new
icinga2::repo class that determines eligibility for a given platform.

This avoids the scenario of including a repository on a system that
doesn't support an external repository.
