### PR TITLE
correct Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '>= 2.7'
+gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}.0" : '>= 2.7'
 gem 'rspec-puppet', '~> 2.0'
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 1'


### PR DESCRIPTION
I think we made a mistake in our testing configuration
Without ".0" every puppet 3.x test is a puppet 3.8.3 test.

Example: https://travis-ci.org/Icinga/puppet-icinga2/jobs/86680988
Search "Using puppet 3" on this site

> Most of the version specifiers, like >= 1.0, are self-explanatory. The specifier ~> has a special meaning, best shown by example. ~> 2.0.3 is identical to >= 2.0.3 and < 2.1. ~> 2.1 is identical to >= 2.1 and < 3.0. ~> 2.2.beta will match prerelease versions like 2.2.beta.12. 
> http://bundler.io/gemfile.html

Now, we have some failed tests, probably because this https://docs.puppetlabs.com/guides/platforms.html#ruby-versions

There is also a mistake with puppet ENV 3.0. Puppet Version 3.0.2 will not be used. I don't know why.

Greetings Reamer
