### PR TITLE
Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ bundler_args: --without system_tests
 
 matrix:
   allow_failures:
-    - env: PUPPET_VERSION="3.7" FUTURE_PARSER="yes"
-    - env: PUPPET_VERSION="3.8" FUTURE_PARSER="yes"
+    - rvm: 1.8.7
   exclude:
     # No support for Ruby 2.1 before Puppet 3.5
     - rvm: 2.1.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,36 @@ language: ruby
 sudo: false
 
 rvm:
+  - 1.8.7
   - 1.9.3
   - 2.0.0
-  - 2.1.3
+  - 2.1.5
+
+# don't load beaker stuff - this does not work with Ruby 1.8
+# and we don't use it on Travis either way
+bundler_args: --without system_tests
 
 matrix:
   allow_failures:
     - env: PUPPET_VERSION="3.7" FUTURE_PARSER="yes"
     - env: PUPPET_VERSION="3.8" FUTURE_PARSER="yes"
+  exclude:
+    # No support for Ruby 2.1 before Puppet 3.5
+    - rvm: 2.1.5
+      env: PUPPET_VERSION="2.7"
+    # No real support for Ruby 1.9.3 on Puppet 2.x
+    - rvm: 1.9.3
+      env: PUPPET_VERSION="2.7"
+    # No support for Ruby 2.0 before Puppet 3.2
+    - rvm: 2.0.0
+      env: PUPPET_VERSION="2.7"
+    # No Puppet 4 on Ruby 1.8
+    - rvm: 1.8.7
+      env: PUPPET_VERSION="4.0"
+    - rvm: 1.8.7
+      env: PUPPET_VERSION="4.1"
+    - rvm: 1.8.7
+      env: PUPPET_VERSION="4.2"
 
 before_install:
   - 'gem install bundler'
@@ -21,11 +43,7 @@ script:
   - bundle exec rake all
 
 env:
-  - PUPPET_VERSION="3.0"
-  - PUPPET_VERSION="3.1"
-  - PUPPET_VERSION="3.2"
-  - PUPPET_VERSION="3.3"
-  - PUPPET_VERSION="3.4"
+  - PUPPET_VERSION="2.7"
   - PUPPET_VERSION="3.5"
   - PUPPET_VERSION="3.6"
   - PUPPET_VERSION="3.7"

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'rspec-puppet', '~> 2.0'
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 1'
 gem 'facter', '>= 1.7.0'
+gem 'metadata-json-lint'
 
 gem 'puppet-lint-strict_indent-check'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,12 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
+# special dependencies for Ruby 1.8
+# since there are still several OSes with it
+if RUBY_VERSION =~ /^1\.8\./
+  gem 'rspec-core', '~> 3.1.7'
+  gem 'nokogiri', '~> 1.5.0'
+end
+
 gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}.0" : '>= 2.7'
 gem 'rspec-puppet', '~> 2.0'
 gem 'puppetlabs_spec_helper', '>= 0.1.0'

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
+require 'metadata-json-lint/rake_task'
 
 if not ENV['SPEC_OPTS']
   ENV['SPEC_OPTS'] = '--format documentation'
@@ -18,4 +19,4 @@ PuppetLint::RakeTask.new :lint do |config|
   config.ignore_paths = PuppetLint.configuration.ignore_paths
 end
 
-task :all => [ :validate, :lint, :spec ]
+task :all => [ :validate, :metadata, :lint, :spec ]

--- a/lib/puppet/icinga2/utils.rb
+++ b/lib/puppet/icinga2/utils.rb
@@ -14,8 +14,10 @@ module Puppet
           value
         else
           if value.class == String
-            if value.match(/^\d+(\.\d+)?$/)
-              return value # return bare value
+            if value.match(/^\d+$/)
+              return value.to_i
+            elsif value.match(/^\d+\.\d+$/)
+              return value.to_f
             else
               # remove quotes from oldstyle values "something"
               value = value.gsub(/(^"|"$)/, '')

--- a/spec/classes/icinga2__service_spec.rb
+++ b/spec/classes/icinga2__service_spec.rb
@@ -11,9 +11,9 @@ describe 'icinga2::service' do
     it { should contain_class('icinga2::service') }
     it { should contain_exec('icinga2 config stamp') }
     it { should contain_exec('icinga2 daemon config test') }
-    it { should contain_service('icinga2').with(
-      :ensure => :running,
-    )}
+    it { should contain_service('icinga2').with({
+      :ensure => 'running',
+    })}
   end
 
 end


### PR DESCRIPTION
This will do 3 things:
- Fix icinga2_config_value on Ruby 1.8.7
- Allow rspec tests on Ruby 1.8 with an older version of rspec
- Update travis definitions with proper values
