### PR TITLE
Add command_endpoint for host objects

### DIFF
--- a/manifests/object/host.pp
+++ b/manifests/object/host.pp
@@ -45,6 +45,7 @@ define icinga2::object::host (
   $target_file_mode = '0644',
   $refresh_icinga2_service = true,
   $zone = undef,
+  $command_endpoint = undef,
 ) {
 
   #Do some validation of the class' parameters:
@@ -61,6 +62,7 @@ define icinga2::object::host (
   validate_string($target_file_mode)
   validate_bool($refresh_icinga2_service)
   validate_string($zone)
+  validate_string($command_endpoint)
 
   #If the refresh_icinga2_service parameter is set to true...
   if $refresh_icinga2_service == true {

--- a/spec/defines/icinga2_object_host_spec.rb
+++ b/spec/defines/icinga2_object_host_spec.rb
@@ -55,6 +55,7 @@ describe 'icinga2::object::host' do
         :object_hostname => 'testhost',
         :display_name => 'testhost',
         :target_file_name => 'testhost.conf',
+        :command_endpoint => 'testcmdhost',
         :vars => {
           'hash_test' => {
             'hash_var1' => 'test',
@@ -84,6 +85,7 @@ describe 'icinga2::object::host' do
           :ensure => 'file',
           :path => '/etc/icinga2/objects/hosts/testhost.conf',
           :content => /object Host "testhost"/,
+          :content => /command_endpoint = "testcmdhost"/,
         }) }
     it { should contain_file(object_file).with_content(/^\s*vars \+= {$/) }
     it { should contain_file(object_file).with_content(/^\s*"array" = \[\n\s+"array1",\n/) }

--- a/templates/object_host.conf.erb
+++ b/templates/object_host.conf.erb
@@ -91,5 +91,7 @@ object Host "<%= @object_hostname %>" {
   <%- if @zone-%>
   zone = "<%= @zone -%>"
   <%- end -%>
-
+  <%- if @command_endpoint -%>
+  command_endpoint = "<%= @command_endpoint -%>"
+  <%- end -%>
 }


### PR DESCRIPTION
Added command_endpoint to the host object. This allows more easier configuration for nodealive check to the host in a distributed setup.  This can be used as a var to reference for service_apply command_endpoint. I have tested this configuration in my test setup and it works great. Icingaweb2 even reports the correct Check Source. 
