### PR TITLE
correction graphite + add new params, which included in icinga 2.4

### DIFF
--- a/manifests/feature/graphite.pp
+++ b/manifests/feature/graphite.pp
@@ -3,14 +3,26 @@
 # Manage and enable graphite of Icinga2
 #
 class icinga2::feature::graphite (
-  $host = '127.0.0.1',
-  $port = 2003
+  $host                   = '127.0.0.1',
+  $port                   = 2003,
+  $host_name_template     = undef,
+  $service_name_template  = undef,
+  # Only avaiable in icinga2 >= 2.4
+  $enable_send_thresholds = undef,
+  $enable_send_metadata   = undef,
+  # This will be only avaiable in some icinga 2 versions for examlple 2.4
+  $enable_legacy_mode     = undef,
 ) {
-
   ::icinga2::object::graphitewriter { 'graphite':
-    host => $host,
-    port => $port,
+    host                   => $host,
+    port                   => $port,
+    host_name_template     => $host_name_template,
+    service_name_template  => $service_name_template,
+    enable_send_thresholds => $enable_send_thresholds,
+    enable_send_metadata   => $enable_send_metadata,
+    enable_legacy_mode     => $enable_legacy_mode,
   }
+
   ::icinga2::feature { 'graphite':
     manage_file => false,
   }

--- a/manifests/feature/graphite.pp
+++ b/manifests/feature/graphite.pp
@@ -8,8 +8,8 @@ class icinga2::feature::graphite (
 ) {
 
   ::icinga2::object::graphitewriter { 'graphite':
-    graphite_host => $host,
-    graphite_port => $port,
+    host => $host,
+    port => $port,
   }
   ::icinga2::feature { 'graphite':
     manage_file => false,

--- a/manifests/object/graphitewriter.pp
+++ b/manifests/object/graphitewriter.pp
@@ -10,16 +10,34 @@
 #
 
 define icinga2::object::graphitewriter (
-  $host       = '127.0.0.1',
-  $port       = 2003,
-  #Put the object files this defined type generates in features-available
-  #since the Graphite writer feature is one that has to be explicitly enabled.
-  $target_dir = '/etc/icinga2/features-available',
-  $file_name  = "${name}.conf",
+  $host                   = '127.0.0.1',
+  $port                   = 2003,
+  $host_name_template     = undef,
+  $service_name_template  = undef,
+  # Only avaiable in icinga2 >= 2.4
+  $enable_send_thresholds = undef,
+  $enable_send_metadata   = undef,
+  # This will be only avaiable in some icinga 2 versions for examlple 2.4
+  $enable_legacy_mode     = undef,
+  # Put the object files this defined type generates in features-available
+  # since the Graphite writer feature is one that has to be explicitly enabled.
+  $target_dir             = '/etc/icinga2/features-available',
+  $file_name              = "${name}.conf",
 ) {
-
-  #Do some validation
+  # Do some validation
   validate_string($host)
+
+  if $enable_send_thresholds != undef {
+    validate_bool($enable_send_thresholds)
+  }
+
+  if $enable_send_metadata != undef {
+    validate_bool($enable_send_metadata)
+  }
+
+  if $enable_legacy_mode != undef {
+    validate_bool($enable_legacy_mode)
+  }
 
   file { "${target_dir}/${file_name}":
     ensure  => file,
@@ -28,6 +46,7 @@ define icinga2::object::graphitewriter (
     mode    => $::icinga2::config_mode,
     content => template('icinga2/object/graphitewriter.conf.erb'),
   }
+
   if $::icinga2::manage_service {
     File["${target_dir}/${file_name}"] ~> Class['::icinga2::service']
   }

--- a/spec/classes/icinga2_feature_graphite_spec.rb
+++ b/spec/classes/icinga2_feature_graphite_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'variants'
+
+describe 'icinga2::feature::graphite' do
+
+  default = 'Debian wheezy'
+
+  let :facts do
+    IcingaPuppet.variants[default]
+  end
+
+  context "on #{default} with default parameters" do
+   let :pre_condition do
+      "include '::icinga2'"
+    end
+
+    it { should contain_class('icinga2::feature::graphite') }
+    it { should contain_icinga2__object__graphitewriter('graphite') }
+    it { should contain_icinga2__feature('graphite').with({
+            :manage_file => false,
+       }) }
+    it { should contain_file('/etc/icinga2/features-available/graphite.conf').with({
+            :ensure => 'file',
+            :path => '/etc/icinga2/features-available/graphite.conf',
+            :content => /object GraphiteWriter "graphite"/,
+       }) }
+  end
+end

--- a/spec/defines/icinga2_object_graphitewriter_spec.rb
+++ b/spec/defines/icinga2_object_graphitewriter_spec.rb
@@ -49,7 +49,45 @@ describe 'icinga2::object::graphitewriter', :type => :define do
           }) }
       it { should contain_file(object_file).with_content(/^\s*host = "www.icinga.org"$/) }
       it { should contain_file(object_file).with_content(/^\s*port = 1234$/) }
+      it { should_not contain_file(object_file).with_content(/^\s*host_name_template/) }
+      it { should_not contain_file(object_file).with_content(/^\s*service_name_template/) }
+      it { should_not contain_file(object_file).with_content(/^\s*enable_send_thresholds/) }
+      it { should_not contain_file(object_file).with_content(/^\s*enable_send_metadata/) }
 
+    end
+    context "on #{name} with more non basic parameters" do
+      let :facts do
+        facts
+      end
+      let :params do
+      {
+        :host => 'www.icinga.org',
+        :port => '1234',
+        :host_name_template => 'icinga.$host.name$',
+        :service_name_template => 'icinga.$host.name$.$service.name$',
+        :enable_send_thresholds => true,
+        :enable_send_metadata => false,
+      }
+      end
+      let :pre_condition do
+        "include 'icinga2'"
+      end
+
+      let(:title) { 'graphite2testserver' }
+
+      object_file = '/etc/icinga2/features-available/graphite2testserver.conf'
+      it { should contain_icinga2__object__graphitewriter('graphite2testserver') }
+      it { should contain_file(object_file).with({
+            :ensure => 'file',
+            :path => '/etc/icinga2/features-available/graphite2testserver.conf',
+            :content => /object GraphiteWriter "graphite2testserver"/,
+          }) }
+      it { should contain_file(object_file).with_content(/^\s*host = "www.icinga.org"$/) }
+      it { should contain_file(object_file).with_content(/^\s*port = 1234$/) }
+      it { should contain_file(object_file).with_content(/^\s*host_name_template = icinga.\$host.name\$$/) }
+      it { should contain_file(object_file).with_content(/^\s*service_name_template = icinga.\$host.name\$.\$service.name\$$/) }
+      it { should contain_file(object_file).with_content(/^\s*enable_send_thresholds = true$/) }
+      it { should contain_file(object_file).with_content(/^\s*enable_send_metadata = false$/) }
     end
   end
 end

--- a/templates/object/graphitewriter.conf.erb
+++ b/templates/object/graphitewriter.conf.erb
@@ -11,4 +11,19 @@ object GraphiteWriter "<%= @name -%>" {
   <%- if @port -%>
   port = <%= @port %>
   <%- end -%>
+  <%- if @host_name_template -%>
+  host_name_template = <%= @host_name_template %>
+  <%- end -%>
+  <%- if @service_name_template -%>
+  service_name_template = <%= @service_name_template %>
+  <%- end -%>
+  <%- if @enable_send_thresholds.is_a? TrueClass or @enable_send_thresholds.is_a? FalseClass -%>
+  enable_send_thresholds = <%= @enable_send_thresholds %>
+  <%- end -%>
+  <%- if @enable_send_metadata.is_a? TrueClass or @enable_send_metadata.is_a? FalseClass -%>
+  enable_send_metadata = <%= @enable_send_metadata %>
+  <%- end -%>
+  <%- if @enable_legacy_mode.is_a? TrueClass or @enable_legacy_mode.is_a? FalseClass -%>
+  enable_legacy_mode = <%= @enable_legacy_mode %>
+  <%- end -%>
 }


### PR DESCRIPTION
I made a mistake in graphite feature class last time. This commit should correct it.

With Icinga2.4 we have new params in graphite object - add support.

Write some spec tests, that this mistake will not happen again.
