### PR TITLE
README: db_password param was changed to db_pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ class { 'icinga2':
   db_port => '5432',
   db_name => 'icinga2_data',
   db_user => 'icinga2',
-  db_password => hiera('icinga_db_password_key_here'),
+  db_pass => hiera('icinga_db_password_key_here'),
 }
 </pre>
 
@@ -197,7 +197,7 @@ class { 'icinga2':
   db_port => '5432'
   db_name => 'icinga2_data'
   db_user => 'icinga2'
-  db_password => 'password',
+  db_pass => 'password',
 }
 </pre>
 


### PR DESCRIPTION
The db_password parameter was renamed, but not all
references to it in the documentation (README.md).

This patch fixes that.
