### PR TITLE
template Header include + Docu-Links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,8 @@
 * Feature: [PR-32](https://github.com/Icinga/puppet-icinga2/pull/32): Added a NotificationCommand object.
 * Feature: [PR-33](https://github.com/Icinga/puppet-icinga2/pull/33): Added an EventCommand object.
 * Feature: [PR-35](https://github.com/Icinga/puppet-icinga2/pull/35): Added the ability to use a static file or custom ERB template for check command objects
-* Feature: [PR-36](https://github.com/Icinga/puppet-icinga2/pull/36) and [dev.icinga.org issue #7216](https://dev.icinga.org/issues/7216): Added a [Notification](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-notification) object defined type.
-* Feature: [PR-37](https://github.com/Icinga/puppet-icinga2/pull/37) and [dev.icinga.org issue #7217](https://dev.icinga.org/issues/7217): Added a [TimePeriod](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-timeperiod) object defined type.
+* Feature: [PR-36](https://github.com/Icinga/puppet-icinga2/pull/36) and [dev.icinga.org issue #7216](https://dev.icinga.org/issues/7216): Added a [Notification](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-notification) object defined type.
+* Feature: [PR-37](https://github.com/Icinga/puppet-icinga2/pull/37) and [dev.icinga.org issue #7217](https://dev.icinga.org/issues/7217): Added a [TimePeriod](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-timeperiod) object defined type.
 * Feature: [PR-39](https://github.com/Icinga/puppet-icinga2/pull/39) and [dev.icinga.org issue #7673](https://dev.icinga.org/issues/7673): Added the ability to purge non-Puppet managed NRPE config files.
 * Feature: [PR-41](https://github.com/Icinga/puppet-icinga2/pull/41) and [dev.icinga.org issue #7674](https://dev.icinga.org/issues/7674): Added CentOS 5 server and NRPE client support.
 * Fix: [PR-40](https://github.com/Icinga/puppet-icinga2/pull/40) and [dev.icinga.org issue #7675](https://dev.icinga.org/issues/7675): Escape single quotes around the `PGPASSWORD` environment variable so that single quotes can be used in the Postgres password

--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ icinga2::object::apilistener { 'master-api':
 
 The `accept_config` and `accept_commands` parameters default to **false**.
 
-See the Icinga 2 documention for more info: [http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-apilistener](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-apilistener)
+See the Icinga 2 documention for more info: [http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-apilistener](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-apilistener)
 
 ####[`icinga2::object::apply_service`](id:object_apply_service)
 
@@ -596,7 +596,7 @@ icinga2::object::compatlogger { 'daily-log':
 </pre>
 
 Both patameters as optionals. The parameter `rotation_method` can one of `HOURLY`, `DAILY`, `WEEKLY` or `MONTHY`.
-See [CompatLogger](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-compatlogger) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for a full list of parameters.
+See [CompatLogger](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-compatlogger) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for a full list of parameters.
 
 ####[`icinga2::object::checkresultreader`](id:object_checkresultreader)
 
@@ -610,7 +610,7 @@ icinga2::object::checkresultreader {'reader':
 }
 </pre>
 
-See [CheckResultReader](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-checkresultreader) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for a full list of parameters.
+See [CheckResultReader](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-checkresultreader) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for a full list of parameters.
 
 ####[`icinga2::object::endpoint`](id:object_endpoint)
 
@@ -623,7 +623,7 @@ icinga2::object::endpoint { 'icinga2b':
 }
 </pre>
 
-See [EndPoint](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-endpoint) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for a full list of parameters.
+See [EndPoint](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-endpoint) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for a full list of parameters.
 
 ####`icinga2::object::eventcommand`
 
@@ -649,7 +649,7 @@ icinga2::object::externalcommandlistener { 'external':
 }
 </pre>
 
-See [ExternalCommandListener](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-externalcommandlistener) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for a full list of parameters.
+See [ExternalCommandListener](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-externalcommandlistener) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for a full list of parameters.
 
 ####[`icinga2::object::gelfwriter`](id:object_gelfwriter)
 
@@ -739,7 +739,7 @@ icinga2::object::icingastatuswriter { 'status':
 }
 </pre>
 
-See [IcingaStatusWriter](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-icingastatuswriter) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for more details about the object.
+See [IcingaStatusWriter](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-icingastatuswriter) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for more details about the object.
 
 ####[`icinga2::object::idomysqlconnection`](id:object_idomysqlconnection)
 
@@ -764,13 +764,13 @@ icinga2::object::idomysqlconnection { 'mysql_connection':
 Some parameters require specific data types to be given:
 
 * `port`: needs to be a [number](https://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#numbers), not a quoted string
-* `cleanup`: If changed from the default value, needs to be given as a [hash](https://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#hashes) with the keys being the cleanup item names and the maximum age as a number (not a quoted string); default values are set to the default values shown in the [Cleanup Items section of the IdomysqlConnection object documentation](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-idomysqlconnection)
+* `cleanup`: If changed from the default value, needs to be given as a [hash](https://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#hashes) with the keys being the cleanup item names and the maximum age as a number (not a quoted string); default values are set to the default values shown in the [Cleanup Items section of the IdomysqlConnection object documentation](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-idomysqlconnection)
 
 All other parameters are given as [single-quoted strings](https://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#single-quoted-strings).
 
 This defined type supports all of the parameters that **IdoMySqlConnection** objects have available.
 
-See [IdoMySqlConnection](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-idomysqlconnection) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for a full list of parameters.
+See [IdoMySqlConnection](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-idomysqlconnection) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for a full list of parameters.
 
 ####[`icinga2::object::idopgsqlconnection`](id:object_idopgsqlconnection)
 
@@ -795,13 +795,13 @@ icinga2::object::idopgsqlconnection { 'postgres_connection':
 Some parameters require specific data types to be given:
 
 * `port`: needs to be a [number](https://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#numbers), not a quoted string
-* `cleanup`: If changed from the default value, needs to be given as a [hash](https://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#hashes) with the keys being the cleanup item names and the maximum age as a number (not a quoted string); default values are set to the default values shown in the [Cleanup Items section of the IdopgsqlConnection object documentation](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-idopgsqlconnection)
+* `cleanup`: If changed from the default value, needs to be given as a [hash](https://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#hashes) with the keys being the cleanup item names and the maximum age as a number (not a quoted string); default values are set to the default values shown in the [Cleanup Items section of the IdopgsqlConnection object documentation](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-idopgsqlconnection)
 
 All other parameters are given as [single-quoted strings](https://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#single-quoted-strings).
 
 This defined type supports all of the parameters that **IdoMySqlConnection** objects have available.
 
-See [IdoPgSqlConnection](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-idopgsqlconnection) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for a full list of parameters.
+See [IdoPgSqlConnection](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-idopgsqlconnection) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for a full list of parameters.
 
 ####[`icinga2::object::livestatuslistener`](id:object_livestatuslistener)
 
@@ -816,7 +816,7 @@ icinga2::object::livestatuslistener { 'livestatus-unix':
 }
 </pre>
 
-See [LivestatusListener](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-livestatuslistener) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for a full list of parameters.
+See [LivestatusListener](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-livestatuslistener) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for a full list of parameters.
 
 ####`icinga2::object::notification`
 
@@ -853,7 +853,7 @@ Available parameters are:
 Notes on specific parameters:
 
 * `vars`: needs to be a hash
-* `users`,`user_groups`,`types`,`states`: should be an array, see [Notification](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-notification) for list of valid state and type filters
+* `users`,`user_groups`,`types`,`states`: should be an array, see [Notification](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-notification) for list of valid state and type filters
 * `times`: needs to be a hash with `begin` and `end` attributes
 * `interval`: needs to be a [number](https://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#numbers), not a quoted string
 
@@ -918,7 +918,7 @@ icinga2::object::perfdatawriter { 'pnp':
 }
 </pre>
 
-See [PerfdataWriter](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-perfdatawriter) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for a full list of parameters.
+See [PerfdataWriter](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-perfdatawriter) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for a full list of parameters.
 
 ####[`icinga2::object::scheduleddowntime`](id:object_scheduleddowntime)
 
@@ -953,7 +953,7 @@ icinga2::object::servicegroup { 'web_services':
 }
 </pre>
 
-See [ServiceGroup](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-servicegroup) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for a full list of parameters.
+See [ServiceGroup](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-servicegroup) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc) for a full list of parameters.
 
 ####[`icinga2::object::statusdatawriter`](id:object_statusdatawriter)
 
@@ -969,7 +969,7 @@ icinga2::object::statusdatawriter { 'status':
 }
 </pre>
 
-See [StatusDataWriter](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-statusdatawriter) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-sysloglogger) for more info.
+See [StatusDataWriter](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-statusdatawriter) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-sysloglogger) for more info.
 
 ####[`icinga2::object::sysloglogger`](id:object_syslogger)
 
@@ -986,7 +986,7 @@ icinga2::object::sysloglogger { 'syslog-warning':
 }
 </pre>
 
-See [SyslogLogger](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-servicegroup) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-sysloglogger) for more info.
+See [SyslogLogger](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-servicegroup) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-sysloglogger) for more info.
 
 ####[`icinga2::object::user`](id:object_user)
 
@@ -1023,7 +1023,7 @@ icinga2::object::timeperiod { 'bra-office-hrs':
 }
 ````
 
-See [TimePeriod](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-timeperiod) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-timeperiod) for more info.
+See [TimePeriod](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-timeperiod) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-timeperiod) for more info.
 
 ####[`icinga2::object::zone`](id:object_zone)
 
@@ -1046,7 +1046,7 @@ icinga2::object::zone { 'satellite':
 }
 ````
 
-See [Zone](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-zone) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-zone) for more info.
+See [Zone](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-zone) on [docs.icinga.org](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-zone) for more info.
 
 [`Hiera`](id:hiera)
 ---------

--- a/manifests/object/apply_dependency.pp
+++ b/manifests/object/apply_dependency.pp
@@ -2,7 +2,7 @@
 #
 #  This is a defined type for Icinga 2 apply dependency objects.
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-dependency
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-dependency
 #
 # === Parameters
 #

--- a/manifests/object/apply_notification_to_host.pp
+++ b/manifests/object/apply_notification_to_host.pp
@@ -2,7 +2,7 @@
 #
 #  This is a defined type for Icinga 2 apply dependency objects.
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-notification
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-notification
 # http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#apply
 #
 # === Parameters

--- a/manifests/object/apply_notification_to_service.pp
+++ b/manifests/object/apply_notification_to_service.pp
@@ -2,7 +2,7 @@
 #
 #  This is a defined type for Icinga 2 apply dependency objects.
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-notification
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-notification
 # http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#apply
 #
 # === Parameters

--- a/manifests/object/apply_service.pp
+++ b/manifests/object/apply_service.pp
@@ -2,7 +2,7 @@
 #
 # This is a defined type for Icinga 2 apply objects that apply services to hosts.
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-host
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-host
 # http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#apply
 #
 # === Parameters

--- a/manifests/object/checkcommand.pp
+++ b/manifests/object/checkcommand.pp
@@ -2,7 +2,7 @@
 #
 # This is a defined type for Icinga 2 apply objects that create check commands
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-checkcommand
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-checkcommand
 #
 # === Parameters
 #

--- a/manifests/object/checkresultreader.pp
+++ b/manifests/object/checkresultreader.pp
@@ -2,7 +2,7 @@
 #
 # This is a defined type for Icinga 2 apply objects that create Check Result Reader
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-checkresultreader
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-checkresultreader
 #
 # === Parameters
 #

--- a/manifests/object/compatlogger.pp
+++ b/manifests/object/compatlogger.pp
@@ -2,7 +2,7 @@
 #
 # This is a defined type for Icinga 2 apply objects that create Compat Logger
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-compatlogger
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-compatlogger
 #
 # === Parameters
 #

--- a/manifests/object/dependency.pp
+++ b/manifests/object/dependency.pp
@@ -2,7 +2,7 @@
 #
 #  This is a defined type for Icinga 2 dependency objects.
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-dependency
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-dependency
 #
 # === Parameters
 #

--- a/manifests/object/endpoint.pp
+++ b/manifests/object/endpoint.pp
@@ -2,7 +2,7 @@
 #
 # This is a defined type for Icinga 2 apply objects that create EndPoint
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-endpoint
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-endpoint
 #
 # === Parameters
 #

--- a/manifests/object/eventcommand.pp
+++ b/manifests/object/eventcommand.pp
@@ -2,7 +2,7 @@
 #
 # This is a defined type for Icinga 2 apply objects that create event commands
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-eventcommand
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-eventcommand
 #
 # === Parameters
 #

--- a/manifests/object/graphitewriter.pp
+++ b/manifests/object/graphitewriter.pp
@@ -2,7 +2,7 @@
 #
 #  This is a defined type for Icinga 2 GraphiteWriter objects.
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-graphitewriter
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-graphitewriter
 #
 # === Parameters
 #

--- a/manifests/object/host.pp
+++ b/manifests/object/host.pp
@@ -2,7 +2,7 @@
 #
 #  This is a defined type for Icinga 2 host objects.
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-host
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-host
 #
 # === Parameters
 #

--- a/manifests/object/hostgroup.pp
+++ b/manifests/object/hostgroup.pp
@@ -2,7 +2,7 @@
 #
 # This is a defined type for Icinga 2 hostgroup objects.
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-hostgroup
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-hostgroup
 #
 # === Parameters
 #

--- a/manifests/object/icingastatuswriter.pp
+++ b/manifests/object/icingastatuswriter.pp
@@ -2,7 +2,7 @@
 #
 # This is a defined type for Icinga 2 apply objects that create IcingaStatusWriter
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-checkercomponent
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-checkercomponent
 #
 # === Parameters
 #

--- a/manifests/object/livestatuslistener.pp
+++ b/manifests/object/livestatuslistener.pp
@@ -2,7 +2,7 @@
 #
 # This is a defined type for Icinga 2 apply objects that create Livestatus Listener
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-livestatuslistener
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-livestatuslistener
 #
 # === Parameters
 #

--- a/manifests/object/notification.pp
+++ b/manifests/object/notification.pp
@@ -2,7 +2,7 @@
 #
 # This is a defined type for Icinga 2 apply objects that create notification commands
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-notification
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-notification
 #
 # === Parameters
 #

--- a/manifests/object/notificationcommand.pp
+++ b/manifests/object/notificationcommand.pp
@@ -2,7 +2,7 @@
 #
 # This is a defined type for Icinga 2 apply objects that create notification commands
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-notificationcommand
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-notificationcommand
 #
 # === Parameters
 #

--- a/manifests/object/perfdatawriter.pp
+++ b/manifests/object/perfdatawriter.pp
@@ -2,7 +2,7 @@
 #
 # This is a defined type for Icinga 2 apply objects that create Perfdata Writer
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-perfdatawriter
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-perfdatawriter
 #
 # === Parameters
 #

--- a/manifests/object/scheduleddowntime.pp
+++ b/manifests/object/scheduleddowntime.pp
@@ -2,7 +2,7 @@
 #
 #  This is a defined type for Icinga 2 ScheduledDowntime objects.
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-scheduleddowntime
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-scheduleddowntime
 #
 # === Parameters
 #

--- a/manifests/object/service.pp
+++ b/manifests/object/service.pp
@@ -2,7 +2,7 @@
 #
 # This is a defined type for Icinga 2 service objects.
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-service
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-service
 #
 # === Parameters
 #

--- a/manifests/object/servicegroup.pp
+++ b/manifests/object/servicegroup.pp
@@ -2,7 +2,7 @@
 #
 # This is a defined type for Icinga 2 servicegroup objects.
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-servicegroup
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-servicegroup
 #
 # === Parameters
 #

--- a/manifests/object/statusdatawriter.pp
+++ b/manifests/object/statusdatawriter.pp
@@ -2,7 +2,7 @@
 #
 # This is a defined type for Icinga 2 apply objects that create StatusDataWriter
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-statusdatawriter
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-statusdatawriter
 #
 # === Parameters
 #

--- a/manifests/object/timeperiod.pp
+++ b/manifests/object/timeperiod.pp
@@ -2,7 +2,7 @@
 #
 #  This is a defined type for Icinga 2 host objects.
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-timeperiod
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-timeperiod
 #
 # === Parameters
 #

--- a/manifests/object/user.pp
+++ b/manifests/object/user.pp
@@ -2,7 +2,7 @@
 #
 #  This is a defined type for Icinga 2 user objects.
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-user
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-user
 #
 # === Parameters
 #

--- a/manifests/object/usergroup.pp
+++ b/manifests/object/usergroup.pp
@@ -2,7 +2,7 @@
 #
 # This is a defined type for Icinga 2 usergroup objects.
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-usergroup
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-usergroup
 #
 # === Parameters
 #

--- a/manifests/object/zone.pp
+++ b/manifests/object/zone.pp
@@ -2,7 +2,7 @@
 #
 #  This is a defined type for Icinga 2 zone objects.
 # See the following Icinga 2 doc page for more info:
-# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/configuring-icinga2#objecttype-zone
+# http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/object-types#objecttype-zone
 #
 # === Parameters
 #

--- a/templates/object/endpoint.conf.erb
+++ b/templates/object/endpoint.conf.erb
@@ -1,4 +1,4 @@
-<%= ERB.new(File.read(File.expand_path('_header.erb',File.dirname(File.dirname(file))))).result(binding) -%>
+<%= scope.function_template(['icinga2/_header.erb']) -%>
 
 object Endpoint "<%= @name %>" {
   <%- if @host -%>

--- a/templates/object/zone.conf.erb
+++ b/templates/object/zone.conf.erb
@@ -1,4 +1,4 @@
-<%= ERB.new(File.read(File.expand_path('_header.erb',File.dirname(File.dirname(file))))).result(binding) -%>
+<%= scope.function_template(['icinga2/_header.erb']) -%>
 
 object Zone "<%= @name %>" {
   <%- if @parent-%>

--- a/templates/zones.conf.erb
+++ b/templates/zones.conf.erb
@@ -1,3 +1,3 @@
-<%= ERB.new(File.read(File.expand_path('_header.erb',File.dirname(file)))).result(binding) -%>
+<%= scope.function_template(['icinga2/_header.erb']) -%>
 
 // This file is not used with the Puppet module!


### PR DESCRIPTION
Hi,

we changed the include from our base header in commit https://github.com/Icinga/puppet-icinga2/commit/536ea58d22306746ba392d0089179a9a8f0dc6b7
+
url to official documentation has changed. Changed with Search & Replace.

Greetings Reamer
