### PR TITLE
Change a default parameter of the host object.

### DIFF
--- a/manifests/object/host.pp
+++ b/manifests/object/host.pp
@@ -38,7 +38,7 @@ define icinga2::object::host (
   $icon_image = undef,
   $icon_image_alt = undef,
   $target_dir = '/etc/icinga2/objects/hosts',
-  $target_file_name = "${fqdn}.conf",
+  $target_file_name = "${name}.conf",
   $target_file_ensure = file,
   $target_file_owner = 'root',
   $target_file_group = 'root',


### PR DESCRIPTION
- This changes the target_file_name parameter of the host object to use
  the $name variable instead of the $fqdn fact to be consistent with the
  other object define types.
- The test hasn't been updated since the results will have the same
  results.
