### PR TITLE
Added custom parameter for apply_service

### DIFF
--- a/manifests/object/apply_service.pp
+++ b/manifests/object/apply_service.pp
@@ -46,7 +46,9 @@ define icinga2::object::apply_service (
   $target_file_owner  = 'root',
   $target_file_group  = 'root',
   $target_file_mode   = '0644',
-  $refresh_icinga2_service = true
+  $refresh_icinga2_service = true,
+  $custom_prepend     = [],
+  $custom_append      = [],
 ) {
 
   #Do some validation of the class' parameters:
@@ -60,6 +62,8 @@ define icinga2::object::apply_service (
   validate_string($target_file_group)
   validate_string($target_file_mode)
   validate_bool($refresh_icinga2_service)
+  validate_array($custom_prepend)
+  validate_array($custom_append)
 
   #If the refresh_icinga2_service parameter is set to true...
   if $refresh_icinga2_service == true {

--- a/spec/defines/icinga2_object_apply_service_spec.rb
+++ b/spec/defines/icinga2_object_apply_service_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+require 'variants'
+
+describe 'icinga2::object::apply_service', :type => :define do
+  IcingaPuppet.variants.each do |name, facts|
+    context "on #{name} with basic parameters" do
+      let :facts do
+        facts
+      end
+      let :pre_condition do
+        " include 'icinga2'"
+      end
+
+      let(:title) { 'check_http' }
+
+      object_file = '/etc/icinga2/objects/applys/check_http.conf'
+      it { should contain_icinga2__object__apply_service('check_http') }
+      it { should contain_file(object_file).with({
+            :ensure => 'file',
+            :path => '/etc/icinga2/objects/applys/check_http.conf',
+            :content => /apply Service "check_http"/,
+          }) }
+      it { should contain_file(object_file).with_content(/^\s*import "generic-service"$/) }
+      it { should_not contain_file(object_file).with_content(/^\s*check_command = "check_http"/) }
+
+    end
+    context "on #{name} with custom_prepend parameter in string format" do
+      let :facts do
+        facts
+      end
+      let :params do
+      {
+        custom_prepend: => 'vars += config',
+      }
+      end
+      let :pre_condition do
+        "include 'icinga2'"
+      end
+
+      let(:title) { 'check_http' }
+
+      object_file = '/etc/icinga2/objects/applys/check_http.conf'
+      it { should contain_icinga2__object__apply_service('check_http') }
+      it { should contain_file(object_file).with({
+            :ensure => 'file',
+            :path => '/etc/icinga2/objects/applys/check_http.conf',
+            :content => /apply Service "check_http"/,
+          }) }
+      it { should contain_file(object_file).with_content(/^\s*import "generic-service"$/) }
+      it { should contain_file(object_file).with_content(/^\s*check_command = "check_http"/) }
+      it { should contain_file(object_file).with_content(/^\s*vars += config/) }
+    end
+    context "on #{name} with custom_append parameter in array format" do
+      let :facts do
+        facts
+      end
+      let :params do
+      {
+        custom_prepend: => ['if (host.vars.notification_type == "sms") {
+         command = "sms-host-notification"
+        } else {
+         command = "mail-host-notification"
+        }', 'vars += config'],
+      }
+      end
+      let :pre_condition do
+        "include 'icinga2'"
+      end
+
+      let(:title) { 'check_http' }
+
+      object_file = '/etc/icinga2/objects/applys/check_http.conf'
+      it { should contain_icinga2__object__apply_service('check_http') }
+      it { should contain_file(object_file).with({
+            :ensure => 'file',
+            :path => '/etc/icinga2/objects/applys/check_http.conf',
+            :content => /apply Service "check_http"/,
+          }) }
+      it { should contain_file(object_file).with_content(/^\s*import "generic-service"$/) }
+      it { should contain_file(object_file).with_content(/^\s*check_command = "check_http"/) }
+      it { should contain_file(object_file).with_content(/^\s*vars += config/) }
+      it { should contain_file(object_file).with_content(/^\s*if (host.vars.notification_type == "sms") \{\n\s+command = "sms-host-notification"\n\s+\} else \{\n\s+command = "mail-host-notification"\n\s+\}/) }
+    end
+  end
+end

--- a/spec/defines/icinga2_object_apply_service_spec.rb
+++ b/spec/defines/icinga2_object_apply_service_spec.rb
@@ -30,7 +30,7 @@ describe 'icinga2::object::apply_service', :type => :define do
       end
       let :params do
         {
-            :custom_prepend =>  ['vars \+= config']
+            :custom_prepend =>  ['vars += config']
         }
       end
       let :pre_condition do
@@ -60,7 +60,7 @@ describe 'icinga2::object::apply_service', :type => :define do
          command = "sms-host-notification"
         } else {
          command = "mail-host-notification"
-        }', 'vars \+= config']
+        }', 'vars += config']
         }
       end
       let :pre_condition do

--- a/spec/defines/icinga2_object_apply_service_spec.rb
+++ b/spec/defines/icinga2_object_apply_service_spec.rb
@@ -21,7 +21,7 @@ describe 'icinga2::object::apply_service', :type => :define do
                                                      :content => /apply Service "check_http"/,
                                                  }) }
       it { should contain_file(object_file).with_content(/^\s*import "generic-service"$/) }
-      it { should_not contain_file(object_file).with_content(/^\s*check_command = "check_http"/) }
+      it { should contain_file(object_file).with_content(/^\s*display_name = "check_http"$/) }
 
     end
     context "on #{name} with custom_prepend parameter" do
@@ -47,7 +47,7 @@ describe 'icinga2::object::apply_service', :type => :define do
                                                      :content => /apply Service "check_http"/,
                                                  }) }
       it { should contain_file(object_file).with_content(/^\s*import "generic-service"$/) }
-      it { should contain_file(object_file).with_content(/^\s*check_command = "check_http"/) }
+      it { should contain_file(object_file).with_content(/^\s*display_name = "check_http"$/) }
       it { should contain_file(object_file).with_content(/^\s*vars \+= config/) }
     end
     context "on #{name} with custom_append parameter" do
@@ -77,7 +77,7 @@ describe 'icinga2::object::apply_service', :type => :define do
                                                      :content => /apply Service "check_http"/,
                                                  }) }
       it { should contain_file(object_file).with_content(/^\s*import "generic-service"$/) }
-      it { should contain_file(object_file).with_content(/^\s*check_command = "check_http"$/) }
+      it { should contain_file(object_file).with_content(/^\s*display_name = "check_http"$/) }
       it { should contain_file(object_file).with_content(/^\s*vars \+= config$/) }
       it { should contain_file(object_file).with_content(/^\s*if \(host.vars.notification_type == "sms"\) \{\n\s+command = "sms-host-notification"\n\s+\} else \{\n\s+command = "mail-host-notification"\n\s+\}$/) }
     end
@@ -93,6 +93,8 @@ describe 'icinga2::object::apply_service', :type => :define do
       let :pre_condition do
         "include 'icinga2'"
       end
+
+      let(:title) { 'check_http' }
 
       it { should raise_error(Puppet::Error, /is not an Array.\s+It looks to be a String/) }
     end

--- a/spec/defines/icinga2_object_apply_service_spec.rb
+++ b/spec/defines/icinga2_object_apply_service_spec.rb
@@ -16,22 +16,22 @@ describe 'icinga2::object::apply_service', :type => :define do
       object_file = '/etc/icinga2/objects/applys/check_http.conf'
       it { should contain_icinga2__object__apply_service('check_http') }
       it { should contain_file(object_file).with({
-            :ensure => 'file',
-            :path => '/etc/icinga2/objects/applys/check_http.conf',
-            :content => /apply Service "check_http"/,
-          }) }
+                                                     :ensure => 'file',
+                                                     :path => '/etc/icinga2/objects/applys/check_http.conf',
+                                                     :content => /apply Service "check_http"/,
+                                                 }) }
       it { should contain_file(object_file).with_content(/^\s*import "generic-service"$/) }
       it { should_not contain_file(object_file).with_content(/^\s*check_command = "check_http"/) }
 
     end
-    context "on #{name} with custom_prepend parameter in string format" do
+    context "on #{name} with custom_prepend parameter" do
       let :facts do
         facts
       end
       let :params do
-      {
-        custom_prepend: => 'vars += config',
-      }
+        {
+            :custom_prepend =>  ['vars \+= config']
+        }
       end
       let :pre_condition do
         "include 'icinga2'"
@@ -42,26 +42,26 @@ describe 'icinga2::object::apply_service', :type => :define do
       object_file = '/etc/icinga2/objects/applys/check_http.conf'
       it { should contain_icinga2__object__apply_service('check_http') }
       it { should contain_file(object_file).with({
-            :ensure => 'file',
-            :path => '/etc/icinga2/objects/applys/check_http.conf',
-            :content => /apply Service "check_http"/,
-          }) }
+                                                     :ensure => 'file',
+                                                     :path => '/etc/icinga2/objects/applys/check_http.conf',
+                                                     :content => /apply Service "check_http"/,
+                                                 }) }
       it { should contain_file(object_file).with_content(/^\s*import "generic-service"$/) }
       it { should contain_file(object_file).with_content(/^\s*check_command = "check_http"/) }
-      it { should contain_file(object_file).with_content(/^\s*vars += config/) }
+      it { should contain_file(object_file).with_content(/^\s*vars \+= config/) }
     end
-    context "on #{name} with custom_append parameter in array format" do
+    context "on #{name} with custom_append parameter" do
       let :facts do
         facts
       end
       let :params do
-      {
-        custom_prepend: => ['if (host.vars.notification_type == "sms") {
+        {
+            :custom_prepend => ['if (host.vars.notification_type == "sms") {
          command = "sms-host-notification"
         } else {
          command = "mail-host-notification"
-        }', 'vars += config'],
-      }
+        }', 'vars \+= config']
+        }
       end
       let :pre_condition do
         "include 'icinga2'"
@@ -72,14 +72,29 @@ describe 'icinga2::object::apply_service', :type => :define do
       object_file = '/etc/icinga2/objects/applys/check_http.conf'
       it { should contain_icinga2__object__apply_service('check_http') }
       it { should contain_file(object_file).with({
-            :ensure => 'file',
-            :path => '/etc/icinga2/objects/applys/check_http.conf',
-            :content => /apply Service "check_http"/,
-          }) }
+                                                     :ensure => 'file',
+                                                     :path => '/etc/icinga2/objects/applys/check_http.conf',
+                                                     :content => /apply Service "check_http"/,
+                                                 }) }
       it { should contain_file(object_file).with_content(/^\s*import "generic-service"$/) }
-      it { should contain_file(object_file).with_content(/^\s*check_command = "check_http"/) }
-      it { should contain_file(object_file).with_content(/^\s*vars += config/) }
-      it { should contain_file(object_file).with_content(/^\s*if (host.vars.notification_type == "sms") \{\n\s+command = "sms-host-notification"\n\s+\} else \{\n\s+command = "mail-host-notification"\n\s+\}/) }
+      it { should contain_file(object_file).with_content(/^\s*check_command = "check_http"$/) }
+      it { should contain_file(object_file).with_content(/^\s*vars \+= config$/) }
+      it { should contain_file(object_file).with_content(/^\s*if \(host.vars.notification_type == "sms"\) \{\n\s+command = "sms-host-notification"\n\s+\} else \{\n\s+command = "mail-host-notification"\n\s+\}$/) }
+    end
+    context "on #{name} with invalid custom_append parameter" do
+      let :facts do
+        facts
+      end
+      let :params do
+        {
+            :custom_prepend =>  'invalid'
+        }
+      end
+      let :pre_condition do
+        "include 'icinga2'"
+      end
+
+      it { should raise_error(Puppet::Error, /is not an Array.\s+It looks to be a String/) }
     end
   end
 end

--- a/templates/object_apply_service.conf.erb
+++ b/templates/object_apply_service.conf.erb
@@ -16,6 +16,11 @@ apply Service "<%= @object_servicename %>" <%= @apply %> {
   <%#- Otherwise, include the parameter: -%>
   import "<%= @template_to_import -%>"
   <%- end -%>
+  <% if @custom_prepend && Array(@custom_prepend).size > 0 -%>
+    <%- Array(@custom_prepend).each do |line| -%>
+    <%= line %>
+    <%- end -%>
+  <% end -%>
   <%- if @display_name -%>
   display_name = "<%= @display_name -%>"
   <%- end -%>
@@ -96,4 +101,9 @@ apply Service "<%= @object_servicename %>" <%= @apply %> {
   <%- if @icon_image_alt -%>
   icon_image_alt = "<%= @icon_image_alt -%>"
   <%- end -%>
+  <% if @custom_append && Array(@custom_append).size > 0 -%>
+    <%- Array(@custom_append).each do |line| -%>
+    <%= line %>
+    <%- end -%>
+  <% end -%>
 }


### PR DESCRIPTION
Hi,

I want use services like this:

```
apply Service "check_http" for (name => config in host.vars.http) {
      import "generic-service"
  display_name = "HTTP " + name + ""
  assign where "linux" in host.groups
  check_command = "check_http"
  vars += config
}
```

Currently, the line "vars += config" is impossible to set via puppet.
