### PR TITLE
Add support for OpenBSD

### DIFF
--- a/manifests/checkplugin.pp
+++ b/manifests/checkplugin.pp
@@ -7,7 +7,7 @@ define icinga2::checkplugin (
   $checkplugin_name                     = $name,
   $checkplugin_libdir                   = $::icinga2::checkplugin_libdir,
   $checkplugin_target_file_owner        = 'root',
-  $checkplugin_target_file_group        = 'root',
+  $checkplugin_target_file_group        = '0',
   $checkplugin_target_file_mode         = '0755',
   $checkplugin_file_distribution_method = 'content',
   $checkplugin_template_module          = 'icinga2',

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -26,7 +26,7 @@ define icinga2::conf (
   $target_dir        = '/etc/icinga2/conf.d',
   $target_file_name  = "${name}.conf",
   $target_file_owner = 'root',
-  $target_file_group = 'root',
+  $target_file_group = '0',
   $target_file_mode  = '0644',
 ) {
 

--- a/manifests/object/apply_dependency.pp
+++ b/manifests/object/apply_dependency.pp
@@ -27,7 +27,7 @@ define icinga2::object::apply_dependency (
   $target_file_name      = "${name}.conf",
   $target_file_ensure    = file,
   $target_file_owner     = 'root',
-  $target_file_group     = 'root',
+  $target_file_group     = '0',
   $target_file_mode      = '0644',
   $refresh_icinga2_service = true,
 ) {

--- a/manifests/object/apply_notification_to_host.pp
+++ b/manifests/object/apply_notification_to_host.pp
@@ -28,7 +28,7 @@ define icinga2::object::apply_notification_to_host (
   $target_file_name        = "${name}.conf",
   $target_file_ensure      = file,
   $target_file_owner       = 'root',
-  $target_file_group       = 'root',
+  $target_file_group       = '0',
   $target_file_mode        = '0644',
   $refresh_icinga2_service = true
 ) {

--- a/manifests/object/apply_notification_to_service.pp
+++ b/manifests/object/apply_notification_to_service.pp
@@ -29,7 +29,7 @@ define icinga2::object::apply_notification_to_service (
   $target_file_name        = "${name}.conf",
   $target_file_ensure      = file,
   $target_file_owner       = 'root',
-  $target_file_group       = 'root',
+  $target_file_group       = '0',
   $target_file_mode        = '0644',
   $refresh_icinga2_service = true
 ) {

--- a/manifests/object/apply_service.pp
+++ b/manifests/object/apply_service.pp
@@ -44,7 +44,7 @@ define icinga2::object::apply_service (
   $target_file_name   = "${name}.conf",
   $target_file_ensure = file,
   $target_file_owner  = 'root',
-  $target_file_group  = 'root',
+  $target_file_group  = '0',
   $target_file_mode   = '0644',
   $refresh_icinga2_service = true,
   $custom_prepend     = [],

--- a/manifests/object/checkcommand.pp
+++ b/manifests/object/checkcommand.pp
@@ -27,7 +27,7 @@ define icinga2::object::checkcommand (
   $target_file_name                      = "${name}.conf",
   $target_file_ensure                    = file,
   $target_file_owner                     = 'root',
-  $target_file_group                     = 'root',
+  $target_file_group                     = '0',
   $target_file_mode                      = '0644',
   $refresh_icinga2_service = true
 ) {

--- a/manifests/object/checkresultreader.pp
+++ b/manifests/object/checkresultreader.pp
@@ -17,7 +17,7 @@ define icinga2::object::checkresultreader (
   $target_file_name             = "${name}.conf",
   $target_file_ensure           = file,
   $target_file_owner            = 'root',
-  $target_file_group            = 'root',
+  $target_file_group            = '0',
   $target_file_mode             = '0644',
   $refresh_icinga2_service = true
 ) {

--- a/manifests/object/compatlogger.pp
+++ b/manifests/object/compatlogger.pp
@@ -18,7 +18,7 @@ define icinga2::object::compatlogger (
   $target_file_name        = "${name}.conf",
   $target_file_ensure      = file,
   $target_file_owner       = 'root',
-  $target_file_group       = 'root',
+  $target_file_group       = '0',
   $target_file_mode        = '0644',
   $refresh_icinga2_service = true
 ) {

--- a/manifests/object/dependency.pp
+++ b/manifests/object/dependency.pp
@@ -24,7 +24,7 @@ define icinga2::object::dependency (
   $target_file_name      = "${name}.conf",
   $target_file_ensure    = file,
   $target_file_owner     = 'root',
-  $target_file_group     = 'root',
+  $target_file_group     = '0',
   $target_file_mode      = '0644',
   $refresh_icinga2_service = true
 ) {

--- a/manifests/object/eventcommand.pp
+++ b/manifests/object/eventcommand.pp
@@ -23,7 +23,7 @@ define icinga2::object::eventcommand (
   $target_file_name   = "${name}.conf",
   $target_file_ensure = file,
   $target_file_owner  = 'root',
-  $target_file_group  = 'root',
+  $target_file_group  = '0',
   $target_file_mode   = '0644',
   $refresh_icinga2_service = true
 ) {

--- a/manifests/object/host.pp
+++ b/manifests/object/host.pp
@@ -41,7 +41,7 @@ define icinga2::object::host (
   $target_file_name = "${name}.conf",
   $target_file_ensure = file,
   $target_file_owner = 'root',
-  $target_file_group = 'root',
+  $target_file_group = '0',
   $target_file_mode = '0644',
   $refresh_icinga2_service = true,
   $zone = undef,

--- a/manifests/object/hostgroup.pp
+++ b/manifests/object/hostgroup.pp
@@ -18,7 +18,7 @@ define icinga2::object::hostgroup (
   $target_file_name = "${name}.conf",
   $target_file_ensure = file,
   $target_file_owner = 'root',
-  $target_file_group = 'root',
+  $target_file_group = '0',
   $target_file_mode = '0644',
   $assign_where = undef,
   $ignore_where = undef,

--- a/manifests/object/icingastatuswriter.pp
+++ b/manifests/object/icingastatuswriter.pp
@@ -17,7 +17,7 @@ define icinga2::object::icingastatuswriter (
   $target_dir                = '/etc/icinga2/objects/icingastatuswriters',
   $target_file_name          = "${name}.conf",
   $target_file_owner         = 'root',
-  $target_file_group         = 'root',
+  $target_file_group         = '0',
   $target_file_mode          = '0644'
 ) {
 

--- a/manifests/object/livestatuslistener.pp
+++ b/manifests/object/livestatuslistener.pp
@@ -20,7 +20,7 @@ define icinga2::object::livestatuslistener (
   $target_file_name               = "${name}.conf",
   $target_file_ensure             = file,
   $target_file_owner              = 'root',
-  $target_file_group              = 'root',
+  $target_file_group              = '0',
   $target_file_mode               = '0644',
   $refresh_icinga2_service = true
 ) {

--- a/manifests/object/notification.pp
+++ b/manifests/object/notification.pp
@@ -28,7 +28,7 @@ define icinga2::object::notification (
   $target_file_name        = "${name}.conf",
   $target_file_ensure      = file,
   $target_file_owner       = 'root',
-  $target_file_group       = 'root',
+  $target_file_group       = '0',
   $target_file_mode        = '0644',
   $refresh_icinga2_service = true
 ) {

--- a/manifests/object/notificationcommand.pp
+++ b/manifests/object/notificationcommand.pp
@@ -23,7 +23,7 @@ define icinga2::object::notificationcommand (
   $target_file_name   = "${name}.conf",
   $target_file_ensure = file,
   $target_file_owner  = 'root',
-  $target_file_group  = 'root',
+  $target_file_group  = '0',
   $target_file_mode   = '0644',
   $refresh_icinga2_service = true
 ) {

--- a/manifests/object/perfdatawriter.pp
+++ b/manifests/object/perfdatawriter.pp
@@ -23,7 +23,7 @@ define icinga2::object::perfdatawriter (
   $target_file_name          = "${name}.conf",
   $target_file_ensure        = file,
   $target_file_owner         = 'root',
-  $target_file_group         = 'root',
+  $target_file_group         = '0',
   $target_file_mode          = '0644',
   $refresh_icinga2_service = true
 ) {

--- a/manifests/object/scheduleddowntime.pp
+++ b/manifests/object/scheduleddowntime.pp
@@ -22,7 +22,7 @@ define icinga2::object::scheduleddowntime (
   $target_file_name             = "${name}.conf",
   $target_file_ensure           = file,
   $target_file_owner            = 'root',
-  $target_file_group            = 'root',
+  $target_file_group            = '0',
   $target_file_mode             = '0644',
   $refresh_icinga2_service = true
 ) {

--- a/manifests/object/service.pp
+++ b/manifests/object/service.pp
@@ -40,7 +40,7 @@ define icinga2::object::service (
   $target_file_name   = "${name}.conf",
   $target_file_ensure = file,
   $target_file_owner  = 'root',
-  $target_file_group  = 'root',
+  $target_file_group  = '0',
   $target_file_mode   = '0644',
   $refresh_icinga2_service = true,
   $zone = undef,

--- a/manifests/object/servicegroup.pp
+++ b/manifests/object/servicegroup.pp
@@ -18,7 +18,7 @@ define icinga2::object::servicegroup (
   $target_file_name = "${name}.conf",
   $target_file_ensure = file,
   $target_file_owner = 'root',
-  $target_file_group = 'root',
+  $target_file_group = '0',
   $target_file_mode = '0644',
   $assign_where = undef,
   $ignore_where = undef,

--- a/manifests/object/statusdatawriter.pp
+++ b/manifests/object/statusdatawriter.pp
@@ -18,7 +18,7 @@ define icinga2::object::statusdatawriter (
   $target_file_name            = "${name}.conf",
   $target_file_ensure          = file,
   $target_file_owner           = 'root',
-  $target_file_group           = 'root',
+  $target_file_group           = '0',
   $target_file_mode            = '0644',
   $refresh_icinga2_service = true
 ) {

--- a/manifests/object/timeperiod.pp
+++ b/manifests/object/timeperiod.pp
@@ -19,7 +19,7 @@ define icinga2::object::timeperiod (
   $target_file_name              = "${name}.conf",
   $target_file_ensure            = file,
   $target_file_owner             = 'root',
-  $target_file_group             = 'root',
+  $target_file_group             = '0',
   $target_file_mode              = '0644',
   $refresh_icinga2_service = true
 ) {

--- a/manifests/object/user.pp
+++ b/manifests/object/user.pp
@@ -25,7 +25,7 @@ define icinga2::object::user (
   $target_file_name = "${name}.conf",
   $target_file_ensure = file,
   $target_file_owner = 'root',
-  $target_file_group = 'root',
+  $target_file_group = '0',
   $target_file_mode = '0644',
   $refresh_icinga2_service = true
 ) {

--- a/manifests/object/usergroup.pp
+++ b/manifests/object/usergroup.pp
@@ -18,7 +18,7 @@ define icinga2::object::usergroup (
   $target_file_name = "${name}.conf",
   $target_file_ensure = file,
   $target_file_owner = 'root',
-  $target_file_group = 'root',
+  $target_file_group = '0',
   $target_file_mode = '0644',
   $assign_where = undef,
   $ignore_where = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -100,6 +100,21 @@ class icinga2::params {
       # Icinga2 client settings
       $checkplugin_libdir   = '/usr/lib/nagios/plugins'
     }
+    'OpenBSD': {
+
+      $plugin_packages = [
+        'monitoring-plugins',
+      ]
+      $mail_package = undef
+
+      #Settings for /etc/icinga2/:
+      $config_owner = 'root'
+      $config_group = '_icinga'
+      $config_mode  = '0640'
+
+      # Icinga2 client settings
+      $checkplugin_libdir   = '/usr/local/libexec/nagios'
+    }
     #Fail if we're on any other OS:
     default: { fail("${::operatingsystem} is not supported!") }
   }


### PR DESCRIPTION
- Add OpenBSD case statement to params.pp
- Change all *target_file_groups from 'root' -> '0', at least on *BSD, there is no group 'root', but is called 'wheel'. Using group '0' instead of a hardcoded name, is a common pattern.  That should help in the future with other *BSD as well. Alternatively there could be something like a OS dependent $root_group in params.pp, and referencing that all over the place. Let me know if you would prefer it that way.

With the following module variables in Hiera, I get a very basic Icinga up and running:

```
icinga2::manage_repos: false
icinga2::install_mailutils: false
icinga2::pid_file: '/var/run/icinga2/icinga2.pid'
```

Alternatively, those variables could be made OS dependent, but for the time being, didn't wanted to go that far (:
