### PR TITLE
Changes to the content of a feature.conf file should trigger a

### DIFF
--- a/manifests/feature.pp
+++ b/manifests/feature.pp
@@ -18,7 +18,7 @@ define icinga2::feature (
     mode  => $::icinga2::config_mode,
   }
 
-  if $manage_file == true {
+  if $manage_file {
 
     if $content {
       $content_rel = $content
@@ -47,6 +47,9 @@ define icinga2::feature (
   }
 
   if $::icinga2::manage_service {
+    if $manage_file {
+      File["icinga2 feature ${name}"] ~> Class['::icinga2::service']
+    }
     File["icinga2 feature ${name} enabled"] ~> Class['::icinga2::service']
   }
 

--- a/spec/defines/icinga2_feature_spec.rb
+++ b/spec/defines/icinga2_feature_spec.rb
@@ -28,6 +28,7 @@ describe 'icinga2::feature' do
       :path   => '/etc/icinga2/features-enabled/checker.conf',
       :target => '../features-available/checker.conf',
     })}
+    it { is_expected.to contain_file("icinga2 feature checker").that_notifies('Class[icinga2::service]') }
   end
 
   context "on default #{default} with file not managed" do
@@ -53,6 +54,7 @@ describe 'icinga2::feature' do
       :ensure => 'link',
       :path => '/etc/icinga2/features-enabled/checker.conf',
     })}
+    it { is_expected.not_to contain_file("icinga2 feature checker").that_notifies('Class[icinga2::service]') }
   end
 
 


### PR DESCRIPTION
restart of icinga

While changing the bind_host parameter to listen on IPv6 instead of IPv4 of the already enabled api feature, I recognized that the file /etc/icinga2/features-available/api.conf successfully got updated, but the service was not restarted.

This little change now triggers a restart of Icinga on feature parameter changes.

I test for if $manage_file == true because the same check is used a bit earlier in that file as well. Alternatively, I could have added the trigger a couple of lines up within the already existing 'f $manage_file == true', and there guarding it with the if $::icinga2::manage_service ... but found this place a bit more appropriate.

let me know if there is something to change/enhance/etc... otherwise please consider for merging 

cheers,
Sebastian
