### PR TITLE
Missing Quotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,20 +215,25 @@ If you would like to install packages to make a `mail` command binary available 
 
 **Enabling and disabling Icinga 2 features**
 
-To manage the features that are enabled or disabled on an Icinga 2 server, you can specify them with the `server_enabled_features` and `server_disabled_features` parameters.
-
-The parameters should be given as arrays of single-quoted strings.
-
-**Note:** Even if you're only specifying one feature, you will still need to specify it as an array.
-
-**Note:** If a feature is listed in both the `server_enabled_features` and `server_disabled_features` arrays, the feature will be **disabled**.
+To manage the features that are enabled or disabled on an Icinga 2 server, you can specify `default_features` to `true` or `false` to enable or disable the features `checker`, `mainlog` and `notification`.
 
 ````
 class { 'icinga2':
   ...
-  server_enabled_features  => ['checker','notification'],
-  server_disabled_features => ['graphite','livestatus'],
+  default_features  => true,
 }
+````
+
+To enable features selectively you need to configure them seperately.
+
+````
+class { 'icinga2::feature::command':
+  command_path => '/var/run/icinga2/cmd/icinga2.cmd',
+}
+````
+
+````
+class { 'icinga2::feature::notification': }
 ````
 
 **Switch from restart to reload Icinga2 service**

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -73,7 +73,6 @@ class icinga2::config {
       '/etc/icinga2/objects/livestatuslisteners',
       '/etc/icinga2/objects/statusdatawriters',
       '/etc/icinga2/objects/applys',
-      '/etc/icinga2/objects/applys_scheduleddowntimes',
       '/etc/icinga2/objects/templates',
       '/etc/icinga2/objects/constants',
     ]:

--- a/manifests/object/apply_scheduleddowntime.pp
+++ b/manifests/object/apply_scheduleddowntime.pp
@@ -19,7 +19,7 @@ define icinga2::object::apply_scheduleddowntime (
   $ignore_where = undef,
   $fixed        = undef,
   $duration     = undef,
-  $target_dir   = '/etc/icinga2/objects/apply_scheduleddowntimes',
+  $target_dir   = '/etc/icinga2/objects/applys',
   $file_name    = "${name}.conf",
 ) {
 

--- a/templates/object/notificationcommand.conf.erb
+++ b/templates/object/notificationcommand.conf.erb
@@ -16,7 +16,7 @@ object NotificationCommand "<%= @object_notificationcommandname %>" {
   <%- end -%>
   <%- if @command -%>
 
-  command = [ <% if @cmd_path -%><%= @cmd_path -%> + <% end -%><% @command.each_with_index do |cmd, i| %><%= cmd -%><%= ', ' if i < (@command.size - 1) %><% end %> ]
+  command = [ <% if @cmd_path -%><%= @cmd_path -%> + <% end -%><% @command.each_with_index do |cmd, i| %>"<%= cmd -%>"<%= ', ' if i < (@command.size - 1) %><% end %> ]
   <%- end -%>
   <%- if @arguments.any? -%>
 


### PR DESCRIPTION
The missing quotation of cmd results in not being able to use ones own path. It has to be changed to the same as in checkcommand template.
