### PR TITLE
Service template check_period quotes

### DIFF
--- a/templates/object/service.conf.erb
+++ b/templates/object/service.conf.erb
@@ -35,7 +35,7 @@
   max_check_attempts = <%= @max_check_attempts %>
   <%- end -%>
   <%- if @check_period -%>
-  check_period = <%= @check_period %>
+  check_period = "<%= @check_period %>"
   <%- end -%>
   <%- if @check_interval -%>
   check_interval = <%= @check_interval %>


### PR DESCRIPTION
Resolves: 

```
Notice: /Stage[main]/Icinga2::Service/Exec[icinga2 daemon config test]/returns: critical/config: Error: syntax error, unexpected T_IDENTIFIER, expecting '}'
Notice: /Stage[main]/Icinga2::Service/Exec[icinga2 daemon config test]/returns: Location: in /etc/icinga2/objects/services/ssh on ****host.conf: 18:20-18:21
Notice: /Stage[main]/Icinga2::Service/Exec[icinga2 daemon config test]/returns: /etc/icinga2/objects/services/ssh on ****host.conf(16):   host_name = "****host"
Notice: /Stage[main]/Icinga2::Service/Exec[icinga2 daemon config test]/returns: /etc/icinga2/objects/services/ssh on ****.com.conf(17):   check_command = "ssh"
Notice: /Stage[main]/Icinga2::Service/Exec[icinga2 daemon config test]/returns: /etc/icinga2/objects/services/ssh on ****host.conf(18):   check_period = 24x7
Notice: /Stage[main]/Icinga2::Service/Exec[icinga2 daemon config test]/returns:                                                                                                      ^^
```
