### PR TITLE
Documentation example quote fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -947,7 +947,7 @@ The `notificationcommand` defined type can create `notificationcommand` objects.
 <pre>
 #Create the mail notification command:
 icinga2::object::notificationcommand { 'mail-service-notification':
-  command   => ['"/icinga2/scripts/mail-notification.sh"'],
+  command   => ['/icinga2/scripts/mail-notification.sh'],
   cmd_path  => 'SysconfDir',
   env       => {
     'NOTIFICATIONTYPE'  => '"$notification.type$"',


### PR DESCRIPTION
The template no longer appears to need the extra quotes to reproduce the
default mail command.  This work simply removes the extra quotes that
caused a syntax error, now resulting in a working configuration.
