### PR TITLE
Fix checkcommand manifest and template

### DIFF
--- a/manifests/object/checkcommand.pp
+++ b/manifests/object/checkcommand.pp
@@ -13,7 +13,7 @@ define icinga2::object::checkcommand (
   $command,
   $object_checkcommandname = $name,
   $templates                             = ['plugin-check-command'],
-  #$methods                             = undef, Need to get more details about this attribute
+  #$methods                               = undef, Need to get more details about this attribute
   $cmd_path                              = 'PluginDir',
   $arguments                             = {},
   $env                                   = {},
@@ -29,24 +29,23 @@ define icinga2::object::checkcommand (
   $target_file_owner                     = 'root',
   $target_file_group                     = '0',
   $target_file_mode                      = '0644',
-  $refresh_icinga2_service = true
+  $refresh_icinga2_service               = true,
 ) {
 
-  #Do some validation of the class' parameters:
+  #Do some validation of the class parameters:
   validate_string($object_checkcommandname)
-  if $checkcommand_template == 'object_checkcommand.conf.erb' {
-    validate_array($templates)
-    if ! is_string($command) {
-      validate_array($command)
-    }
-    validate_string($cmd_path)
-    
-    validate_hash($env)
-    
-    validate_hash($vars)
-    if $timeout {
-      validate_re($timeout, '^\d+$')
-    }
+  validate_array($templates)
+  if ! is_array($command) {
+    validate_string($command)
+  }
+  if ! is_string($command) {
+    validate_array($command)
+  }
+  validate_string($cmd_path)
+  validate_hash($env)
+  validate_hash($vars)
+  if $timeout {
+    validate_re($timeout, '^\d+$')
   }
   validate_string($target_dir)
   validate_string($target_file_name)

--- a/spec/defines/icinga2__object/checkcommand_spec.rb
+++ b/spec/defines/icinga2__object/checkcommand_spec.rb
@@ -50,13 +50,13 @@ describe 'icinga2::object::checkcommand' do
     let(:params) do
       {
         :object_checkcommandname => 'testcheckcommand',
-        :command => [ 'testcommand1' , 'testcommand2']
+        :command => [ 'testcommand1' , 'argument1', 'argument2' ]
       }
     end
 
     object_file = '/etc/icinga2/objects/checkcommands/testcheckcommand.conf'
     it { should contain_icinga2__object__checkcommand('testcheckcommand') }
-    it { should contain_file(object_file).with_content(/^\s*command = \[ PluginDir \+ "testcommand1", PluginDir \+ "testcommand2" \]$/) }
+    it { should contain_file(object_file).with_content(/^\s*command = \[ PluginDir \+ "testcommand1", "argument1", "argument2" \]$/) }
 
   end
 

--- a/templates/object/checkcommand.conf.erb
+++ b/templates/object/checkcommand.conf.erb
@@ -15,7 +15,8 @@ object CheckCommand "<%= @object_checkcommandname %>" {
   import "<%= t -%>"
   <%- end -%>
   <%- if @command -%>
-  command = [ <% @command.each_with_index do |cmd, i| %><% if @cmd_path -%><%= @cmd_path -%> + <% end -%>"<%= cmd -%>"<%= ', ' if i < (@command.size - 1) %><% end %> ]
+  <%- a_command = [@command].flatten.compact -%>
+  command = [ <% a_command.each_with_index do |cmd, i| %><% if @cmd_path and i == 0 -%><%= @cmd_path -%> + <% end -%>"<%= cmd -%>"<%= ', ' if i < (a_command.size - 1) %><% end %> ]
   <%- end -%>
   <%- if @arguments.any? -%>
 


### PR DESCRIPTION
Update the validation of the parameters in the checkcommand manifest. Remove the obsolete
"if" statement which prevents necessary parameter validations. The parameter "command"
can either be an array or a string.

Fix the template. Make sure the "command" parameter is passed as an array to the
"each_with_index" method, otherwise an exeption is thrown. If the "command" parameter
consists of an array of individual command arguments, don't add the command path to
each element of the array. This should only be done for the first element of the
array (the command).

This fixes establish the desired behavior for the "command" parameter as described in
the icinga2 docs.

Update the rspec tests.
