### PR TITLE
Fix icinga_ca_port usage in `icinga2 pki` command

### DIFF
--- a/manifests/pki/icinga.pp
+++ b/manifests/pki/icinga.pp
@@ -50,14 +50,14 @@ class icinga2::pki::icinga (
   } ->
 
   exec { 'icinga2 pki get trusted-cert':
-    command => "icinga2 pki save-cert --host '${icinga_ca_host}'${icinga_ca_port} --key '${key}' --cert '${cert}' --trustedcert '${trusted_cert}'",
+    command => "icinga2 pki save-cert --host '${icinga_ca_host}'${_icinga_ca_port} --key '${key}' --cert '${cert}' --trustedcert '${trusted_cert}'",
     creates => $trusted_cert,
   } ->
   file { $trusted_cert:
   } ->
 
   exec { 'icinga2 pki request':
-    command => "icinga2 pki request --host '${icinga_ca_host}'${icinga_ca_port} --ca '${ca}' --key '${key}' --cert '${cert}' --trustedcert '${trusted_cert}' --ticket '${ticket_id}'",
+    command => "icinga2 pki request --host '${icinga_ca_host}'${_icinga_ca_port} --ca '${ca}' --key '${key}' --cert '${cert}' --trustedcert '${trusted_cert}' --ticket '${ticket_id}'",
     creates => $ca,
   } ->
   file { $ca:


### PR DESCRIPTION
It looks like we used wrong variable in the `icinga2 pki` command. Bellow is my error:

```
Error: icinga2 pki request --host 'masterserver.local'5665 --ca '/etc/icinga2/pki/ca.crt' --key '/etc/icinga2/pki/satellite1.local.key' --cert '/etc/icinga2/pki/satellite1.local.crt' --trustedcert '/etc/icinga2/pki/trusted-cert.crt' --ticket '243de7fd4578bda368af92a4d81d058a6d92a592' returned 1 instead of one of [0]
```

This PR is for fixing that error. Please help to review it :)
