### PR TITLE
Add prefix parameters

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -23,7 +23,7 @@ define icinga2::conf (
   $template          = undef,
   $options_hash      = undef,
   $ensure            = present,
-  $target_dir        = '/etc/icinga2/conf.d',
+  $target_dir        = "${::icinga2::config_dir}/conf.d",
   $target_file_name  = "${name}.conf",
   $target_file_owner = $::icinga2::config_owner,
   $target_file_group = $::icinga2::config_group,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,10 +14,10 @@ class icinga2::config {
   # maintained directories
   file {
     [
-      '/etc/icinga2',
-      '/etc/icinga2/pki',
-      '/etc/icinga2/scripts',
-      '/etc/icinga2/features-available',
+      $::icinga2::config_dir,
+      "${::icinga2::config_dir}/pki",
+      "${::icinga2::config_dir}/scripts",
+      "${::icinga2::config_dir}/features-available",
     ]:
       ensure => directory,
   }
@@ -25,7 +25,7 @@ class icinga2::config {
   # TODO: temporary until we provide some default templates
   file {
     [
-      '/etc/icinga2/conf.d',
+      "${::icinga2::config_dir}/conf.d",
     ]:
       ensure  => directory,
       purge   => $::icinga2::purge_confd,
@@ -35,9 +35,9 @@ class icinga2::config {
 
   file {
     [
-      '/etc/icinga2/features-enabled',
-      '/etc/icinga2/objects',
-      '/etc/icinga2/zones.d',
+      "${::icinga2::config_dir}/features-enabled",
+      "${::icinga2::config_dir}/objects",
+      "${::icinga2::config_dir}/zones.d",
     ]:
       ensure  => directory,
       purge   => $::icinga2::purge_configs,
@@ -45,7 +45,7 @@ class icinga2::config {
       force   => $::icinga2::purge_configs,
   }
 
-  file { '/etc/icinga2/icinga2.conf':
+  file { "${::icinga2::config_dir}/icinga2.conf":
     ensure  => file,
     content => template($::icinga2::config_template),
   }
@@ -53,28 +53,28 @@ class icinga2::config {
   # maintained object directories
   file {
     [
-      '/etc/icinga2/objects/hosts',
-      '/etc/icinga2/objects/hostgroups',
-      '/etc/icinga2/objects/services',
-      '/etc/icinga2/objects/servicegroups',
-      '/etc/icinga2/objects/users',
-      '/etc/icinga2/objects/usergroups',
-      '/etc/icinga2/objects/checkcommands',
-      '/etc/icinga2/objects/notificationcommands',
-      '/etc/icinga2/objects/eventcommands',
-      '/etc/icinga2/objects/notifications',
-      '/etc/icinga2/objects/timeperiods',
-      '/etc/icinga2/objects/scheduleddowntimes',
-      '/etc/icinga2/objects/dependencies',
-      '/etc/icinga2/objects/perfdatawriters',
-      '/etc/icinga2/objects/graphitewriters',
-      '/etc/icinga2/objects/idomysqlconnections',
-      '/etc/icinga2/objects/idopgsqlconnections',
-      '/etc/icinga2/objects/livestatuslisteners',
-      '/etc/icinga2/objects/statusdatawriters',
-      '/etc/icinga2/objects/applys',
-      '/etc/icinga2/objects/templates',
-      '/etc/icinga2/objects/constants',
+      "${::icinga2::config_dir}/objects/hosts",
+      "${::icinga2::config_dir}/objects/hostgroups",
+      "${::icinga2::config_dir}/objects/services",
+      "${::icinga2::config_dir}/objects/servicegroups",
+      "${::icinga2::config_dir}/objects/users",
+      "${::icinga2::config_dir}/objects/usergroups",
+      "${::icinga2::config_dir}/objects/checkcommands",
+      "${::icinga2::config_dir}/objects/notificationcommands",
+      "${::icinga2::config_dir}/objects/eventcommands",
+      "${::icinga2::config_dir}/objects/notifications",
+      "${::icinga2::config_dir}/objects/timeperiods",
+      "${::icinga2::config_dir}/objects/scheduleddowntimes",
+      "${::icinga2::config_dir}/objects/dependencies",
+      "${::icinga2::config_dir}/objects/perfdatawriters",
+      "${::icinga2::config_dir}/objects/graphitewriters",
+      "${::icinga2::config_dir}/objects/idomysqlconnections",
+      "${::icinga2::config_dir}/objects/idopgsqlconnections",
+      "${::icinga2::config_dir}/objects/livestatuslisteners",
+      "${::icinga2::config_dir}/objects/statusdatawriters",
+      "${::icinga2::config_dir}/objects/applys",
+      "${::icinga2::config_dir}/objects/templates",
+      "${::icinga2::config_dir}/objects/constants",
     ]:
       ensure  => directory,
       purge   => $::icinga2::purge_configs,
@@ -82,7 +82,7 @@ class icinga2::config {
       force   => $::icinga2::purge_configs,
   }
 
-  file { '/etc/icinga2/zones.conf':
+  file { "${::icinga2::config_dir}/zones.conf":
     ensure  => file,
     content => template('icinga2/zones.conf.erb'),
   }

--- a/manifests/config/objectdir.pp
+++ b/manifests/config/objectdir.pp
@@ -17,7 +17,7 @@ define icinga2::config::objectdir {
   Class['icinga2::config'] ->
   file { "icinga2 objectdir ${name}":
     ensure  => directory,
-    path    => "/etc/icinga2/objects/${name}",
+    path    => "${::icinga2::config_dir}/objects/${name}",
     owner   => $::icinga2::config_owner,
     group   => $::icinga2::config_group,
     mode    => $::icinga2::config_mode,

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -26,8 +26,8 @@ class icinga2::database {
     exec { 'mysql_schema_load':
       user    => 'root',
       path    => $::path,
-      command => "mysql -h '${::icinga2::db_host}' -u '${::icinga2::db_user}' -p'${::icinga2::db_pass}' '${::icinga2::db_name}' < '${db_schema}' && touch /etc/icinga2/mysql_schema_loaded.txt",
-      creates => '/etc/icinga2/mysql_schema_loaded.txt',
+      command => "mysql -h '${::icinga2::db_host}' -u '${::icinga2::db_user}' -p'${::icinga2::db_pass}' '${::icinga2::db_name}' < '${db_schema}' && touch ${::icinga2::config_dir}/mysql_schema_loaded.txt",
+      creates => "${::icinga2::config_dir}/mysql_schema_loaded.txt",
     }
   }
   elsif $::icinga2::db_type == 'pgsql' {
@@ -47,8 +47,8 @@ class icinga2::database {
       environment => [
         "PGPASSWORD=${::icinga2::db_pass}",
       ],
-      command     => "psql -U '${::icinga2::db_user}' -h '${::icinga2::db_host}' ${port} -d '${::icinga2::db_name}' < '${db_schema}' && touch /etc/icinga2/postgres_schema_loaded.txt",
-      creates     => '/etc/icinga2/postgres_schema_loaded.txt',
+      command     => "psql -U '${::icinga2::db_user}' -h '${::icinga2::db_host}' ${port} -d '${::icinga2::db_name}' < '${db_schema}' && touch ${::icinga2::config_dir}/postgres_schema_loaded.txt",
+      creates     => "${::icinga2::config_dir}/postgres_schema_loaded.txt",
     }
   }
 

--- a/manifests/feature.pp
+++ b/manifests/feature.pp
@@ -33,7 +33,7 @@ define icinga2::feature (
     Class['icinga2::config'] ->
     file { "icinga2 feature ${name}":
       ensure  => file,
-      path    => "/etc/icinga2/features-available/${name}.conf",
+      path    => "${::icinga2::config_dir}/features-available/${name}.conf",
       content => $content_rel,
     } ->
     File["icinga2 feature ${name} enabled"]
@@ -42,8 +42,8 @@ define icinga2::feature (
 
   file { "icinga2 feature ${name} enabled":
     ensure => link,
-    path   => "/etc/icinga2/features-enabled/${name}.conf",
-    target => "../features-available/${name}.conf",
+    path   => "${::icinga2::config_dir}/features-enabled/${name}.conf",
+    target => "${::icinga2::config_dir}/features-available/${name}.conf",
   }
 
   if $::icinga2::manage_service {

--- a/manifests/feature/api.pp
+++ b/manifests/feature/api.pp
@@ -8,9 +8,9 @@
 class icinga2::feature::api (
   $accept_commands = false,
   $accept_config   = false,
-  $ca_path         = '/etc/icinga2/pki/ca.crt',
-  $cert_path       = "/etc/icinga2/pki/${::fqdn}.crt",
-  $key_path        = "/etc/icinga2/pki/${::fqdn}.key",
+  $ca_path         = "${::icinga2::config_dir}/pki/ca.crt",
+  $cert_path       = "${::icinga2::config_dir}/pki/${::fqdn}.crt",
+  $key_path        = "${::icinga2::config_dir}/pki/${::fqdn}.key",
   $crl_path        = undef,
   $bind_host       = undef,
   $bind_port       = undef,

--- a/manifests/feature/debuglog.pp
+++ b/manifests/feature/debuglog.pp
@@ -4,7 +4,7 @@
 #
 class icinga2::feature::debuglog (
   $severity = 'debug',
-  $path     = '/var/log/icinga2/debug.log'
+  $path     = "${::icinga2::var_dir}/log/icinga2/debug.log"
 ) {
 
   validate_string($severity)

--- a/manifests/feature/graphite.pp
+++ b/manifests/feature/graphite.pp
@@ -21,7 +21,7 @@ class icinga2::feature::graphite (
     enable_send_thresholds => $enable_send_thresholds,
     enable_send_metadata   => $enable_send_metadata,
     enable_legacy_mode     => $enable_legacy_mode,
-    target_dir             => '/etc/icinga2/features-available',
+    target_dir             => "${::icinga2::config_dir}/features-available",
   }
 
   ::icinga2::feature { 'graphite':

--- a/manifests/feature/ido_mysql.pp
+++ b/manifests/feature/ido_mysql.pp
@@ -51,7 +51,7 @@ class icinga2::feature::ido_mysql (
     cleanup              => $cleanup,
     categories           => $categories,
     target_file_name     => 'ido-mysql.conf',
-    target_dir           => '/etc/icinga2/features-available',
+    target_dir           => "${::icinga2::config_dir}/features-available",
   } ->
 
   ::icinga2::feature { 'ido-mysql':

--- a/manifests/feature/ido_pgsql.pp
+++ b/manifests/feature/ido_pgsql.pp
@@ -51,7 +51,7 @@ class icinga2::feature::ido_pgsql (
     cleanup              => $cleanup,
     categories           => $categories,
     target_file_name     => 'ido-pgsql.conf',
-    target_dir           => '/etc/icinga2/features-available',
+    target_dir           => "${::icinga2::config_dir}/features-available",
   } ->
 
   ::icinga2::feature { 'ido-pgsql':

--- a/manifests/feature/mainlog.pp
+++ b/manifests/feature/mainlog.pp
@@ -4,7 +4,7 @@
 #
 class icinga2::feature::mainlog (
   $severity = 'information',
-  $path     = '/var/log/icinga2/icinga2.log'
+  $path     = "${::icinga2::var_dir}/log/icinga2/icinga2.log"
 ) {
 
   validate_string($severity)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,10 @@ class icinga2 (
   $db_schema_pgsql                        = $::icinga2::params::db_schema_pgsql,
   $pid_file                               = $::icinga2::params::pid_file,
   $restart_cmd                            = $::icinga2::params::restart_cmd,
+  $config_dir                             = $::icinga2::params::config_dir,
+  $sbin_dir                               = $::icinga2::params::sbin_dir,
+  $share_dir                              = $::icinga2::params::share_dir,
+  $var_dir                                = $::icinga2::params::var_dir,
 ) inherits ::icinga2::params {
   # TODO: temporary parameter until we provide some default templates
   validate_bool($purge_confd)

--- a/manifests/object/apiuser.pp
+++ b/manifests/object/apiuser.pp
@@ -13,7 +13,7 @@ define icinga2::object::apiuser (
   $password    = undef,
   $client_cn   = undef,
   $permissions = ['*'],
-  $target_dir  = '/etc/icinga2/objects/apiusers',
+  $target_dir  = "${::icinga2::config_dir}/objects/apiusers",
   $file_name   = "${name}.conf",
 ) {
 

--- a/manifests/object/apply_dependency.pp
+++ b/manifests/object/apply_dependency.pp
@@ -23,7 +23,7 @@ define icinga2::object::apply_dependency (
   $states                  = [],
   $assign_where            = undef,
   $ignore_where            = undef,
-  $target_dir              = '/etc/icinga2/objects/applys',
+  $target_dir              = "${::icinga2::config_dir}/objects/applys",
   $target_file_name        = "${name}.conf",
   $target_file_ensure      = file,
   $target_file_owner       = $::icinga2::config_owner,

--- a/manifests/object/apply_notification_to_host.pp
+++ b/manifests/object/apply_notification_to_host.pp
@@ -24,7 +24,7 @@ define icinga2::object::apply_notification_to_host (
   $period                  = undef,
   $types                   = [],
   $states                  = [],
-  $target_dir              = '/etc/icinga2/objects/applys',
+  $target_dir              = "${::icinga2::config_dir}/objects/applys",
   $target_file_name        = "${name}.conf",
   $target_file_ensure      = file,
   $target_file_owner       = $::icinga2::config_owner,

--- a/manifests/object/apply_notification_to_service.pp
+++ b/manifests/object/apply_notification_to_service.pp
@@ -25,7 +25,7 @@ define icinga2::object::apply_notification_to_service (
   $period                  = undef,
   $types                   = [],
   $states                  = [],
-  $target_dir              = '/etc/icinga2/objects/applys',
+  $target_dir              = "${::icinga2::config_dir}/objects/applys",
   $target_file_name        = "${name}.conf",
   $target_file_ensure      = file,
   $target_file_owner       = $::icinga2::config_owner,

--- a/manifests/object/apply_scheduleddowntime.pp
+++ b/manifests/object/apply_scheduleddowntime.pp
@@ -19,7 +19,7 @@ define icinga2::object::apply_scheduleddowntime (
   $ignore_where = undef,
   $fixed        = undef,
   $duration     = undef,
-  $target_dir   = '/etc/icinga2/objects/applys',
+  $target_dir   = "${::icinga2::config_dir}/objects/applys",
   $file_name    = "${name}.conf",
 ) {
 

--- a/manifests/object/apply_service.pp
+++ b/manifests/object/apply_service.pp
@@ -40,7 +40,7 @@ define icinga2::object::apply_service (
   $action_url              = undef,
   $icon_image              = undef,
   $icon_image_alt          = undef,
-  $target_dir              = '/etc/icinga2/objects/applys',
+  $target_dir              = "${::icinga2::config_dir}/objects/applys",
   $target_file_name        = "${name}.conf",
   $target_file_ensure      = file,
   $target_file_owner       = $::icinga2::config_owner,

--- a/manifests/object/checkcommand.pp
+++ b/manifests/object/checkcommand.pp
@@ -22,7 +22,7 @@ define icinga2::object::checkcommand (
   $refresh_icinga2_service               = true,
   $sudo                                  = false,
   $sudo_cmd                              = '/usr/bin/sudo',
-  $target_dir                            = '/etc/icinga2/objects/checkcommands',
+  $target_dir                            = "${::icinga2::config_dir}/objects/checkcommands",
   $target_file_ensure                    = file,
   $target_file_group                     = $::icinga2::config_group,
   $target_file_mode                      = $::icinga2::config_mode,

--- a/manifests/object/checkresultreader.pp
+++ b/manifests/object/checkresultreader.pp
@@ -13,7 +13,7 @@ define icinga2::object::checkresultreader (
   $ensure                       = 'file',
   $object_checkresultreadername = $name,
   $spool_dir                    = undef,
-  $target_dir                   = '/etc/icinga2/objects/checkresultreaders',
+  $target_dir                   = "${::icinga2::config_dir}/objects/checkresultreaders",
   $target_file_name             = "${name}.conf",
   $target_file_ensure           = file,
   $target_file_owner            = $::icinga2::config_owner,

--- a/manifests/object/compatlogger.pp
+++ b/manifests/object/compatlogger.pp
@@ -14,7 +14,7 @@ define icinga2::object::compatlogger (
   $object_compatloggername = $name,
   $log_dir                 = undef,
   $rotation_method         = undef,
-  $target_dir              = '/etc/icinga2/objects/compatloggers',
+  $target_dir              = "${::icinga2::config_dir}/objects/compatloggers",
   $target_file_name        = "${name}.conf",
   $target_file_ensure      = file,
   $target_file_owner       = $::icinga2::config_owner,

--- a/manifests/object/dependency.pp
+++ b/manifests/object/dependency.pp
@@ -20,7 +20,7 @@ define icinga2::object::dependency (
   $disable_notifications   = undef,
   $period                  = undef,
   $states                  = [],
-  $target_dir              = '/etc/icinga2/objects/dependencies',
+  $target_dir              = "${::icinga2::config_dir}/objects/dependencies",
   $target_file_name        = "${name}.conf",
   $target_file_ensure      = file,
   $target_file_owner       = $::icinga2::config_owner,

--- a/manifests/object/endpoint.pp
+++ b/manifests/object/endpoint.pp
@@ -13,7 +13,7 @@ define icinga2::object::endpoint (
   $host         = undef,
   $port         = undef,
   $log_duration = undef,
-  $target_dir   = '/etc/icinga2/objects/endpoints',
+  $target_dir   = "${::icinga2::config_dir}/objects/endpoints",
   $file_name    = "${name}.conf",
 ) {
 

--- a/manifests/object/eventcommand.pp
+++ b/manifests/object/eventcommand.pp
@@ -19,7 +19,7 @@ define icinga2::object::eventcommand (
   $env                     = {},
   $vars                    = {},
   $timeout                 = undef,
-  $target_dir              = '/etc/icinga2/objects/eventcommands',
+  $target_dir              = "${::icinga2::config_dir}/objects/eventcommands",
   $target_file_name        = "${name}.conf",
   $target_file_ensure      = file,
   $target_file_owner       = $::icinga2::config_owner,

--- a/manifests/object/gelfwriter.pp
+++ b/manifests/object/gelfwriter.pp
@@ -15,7 +15,7 @@ define icinga2::object::gelfwriter (
   $source     = undef,
   # Put the object files this defined type generates in features-available
   # since the Gelf writer feature is one that has to be explicitly enabled.
-  $target_dir = '/etc/icinga2/features-available',
+  $target_dir = "${::icinga2::config_dir}/features-available",
   $file_name  = "${name}.conf",
 ) {
   # Do some validation

--- a/manifests/object/graphitewriter.pp
+++ b/manifests/object/graphitewriter.pp
@@ -21,7 +21,7 @@ define icinga2::object::graphitewriter (
   $enable_legacy_mode     = undef,
   # Put the object files this defined type generates in features-available
   # since the Graphite writer feature is one that has to be explicitly enabled.
-  $target_dir             = '/etc/icinga2/objects/graphitewriters',
+  $target_dir             = "${::icinga2::config_dir}/objects/graphitewriters",
   $file_name              = "${name}.conf",
 ) {
   # Do some validation

--- a/manifests/object/host.pp
+++ b/manifests/object/host.pp
@@ -38,7 +38,7 @@ define icinga2::object::host (
   $action_url              = undef,
   $icon_image              = undef,
   $icon_image_alt          = undef,
-  $target_dir              = '/etc/icinga2/objects/hosts',
+  $target_dir              = "${::icinga2::config_dir}/objects/hosts",
   $target_file_name        = "${name}.conf",
   $target_file_ensure      = file,
   $target_file_owner       = $::icinga2::config_owner,

--- a/manifests/object/hostgroup.pp
+++ b/manifests/object/hostgroup.pp
@@ -14,7 +14,7 @@ define icinga2::object::hostgroup (
   $display_name            = $name,
   $templates               = [],
   $groups                  = [],
-  $target_dir              = '/etc/icinga2/objects/hostgroups',
+  $target_dir              = "${::icinga2::config_dir}/objects/hostgroups",
   $target_file_name        = "${name}.conf",
   $target_file_ensure      = file,
   $target_file_owner       = $::icinga2::config_owner,

--- a/manifests/object/icingastatuswriter.pp
+++ b/manifests/object/icingastatuswriter.pp
@@ -14,7 +14,7 @@ define icinga2::object::icingastatuswriter (
   $object_name               = $name,
   $status_path               = undef,
   $update_interval           = undef,
-  $target_dir                = '/etc/icinga2/objects/icingastatuswriters',
+  $target_dir                = "${::icinga2::config_dir}/objects/icingastatuswriters",
   $target_file_name          = "${name}.conf",
   $target_file_owner         = $::icinga2::config_owner,
   $target_file_group         = $::icinga2::config_group,

--- a/manifests/object/idomysqlconnection.pp
+++ b/manifests/object/idomysqlconnection.pp
@@ -32,7 +32,7 @@ define icinga2::object::idomysqlconnection (
   },
   $categories      = [],
   $target_file_name     = "${name}.conf",
-  $target_dir           = '/etc/icinga2/objects/idomysqlconnections',
+  $target_dir           = "${::icinga2::config_dir}/objects/idomysqlconnections",
   $refresh_service      = $::icinga2::manage_service,
 ) {
 

--- a/manifests/object/idopgsqlconnection.pp
+++ b/manifests/object/idopgsqlconnection.pp
@@ -32,7 +32,7 @@ define icinga2::object::idopgsqlconnection (
   },
   $categories           = [],
   $target_file_name     = "${name}.conf",
-  $target_dir           = '/etc/icinga2/objects/idopgsqlconnections',
+  $target_dir           = "${::icinga2::config_dir}/objects/idopgsqlconnections",
   $refresh_service      = $::icinga2::manage_service,
 ) {
 

--- a/manifests/object/livestatuslistener.pp
+++ b/manifests/object/livestatuslistener.pp
@@ -16,7 +16,7 @@ define icinga2::object::livestatuslistener (
   $bind_port                      = undef,
   $socket_path                    = undef,
   $compat_log_path                = undef,
-  $target_dir                     = '/etc/icinga2/objects/livestatuslisteners',
+  $target_dir                     = "${::icinga2::config_dir}/objects/livestatuslisteners",
   $target_file_name               = "${name}.conf",
   $target_file_ensure             = file,
   $target_file_owner              = $::icinga2::config_owner,

--- a/manifests/object/notification.pp
+++ b/manifests/object/notification.pp
@@ -24,7 +24,7 @@ define icinga2::object::notification (
   $period                  = undef,
   $types                   = [],
   $states                  = [],
-  $target_dir              = '/etc/icinga2/objects/notifications',
+  $target_dir              = "${::icinga2::config_dir}/objects/notifications",
   $target_file_name        = "${name}.conf",
   $target_file_ensure      = file,
   $target_file_owner       = $::icinga2::config_owner,

--- a/manifests/object/notificationcommand.pp
+++ b/manifests/object/notificationcommand.pp
@@ -19,7 +19,7 @@ define icinga2::object::notificationcommand (
   $env                            = {},
   $vars                           = {},
   $timeout                        = undef,
-  $target_dir                     = '/etc/icinga2/objects/notificationcommands',
+  $target_dir                     = "${::icinga2::config_dir}/objects/notificationcommands",
   $target_file_name               = "${name}.conf",
   $target_file_ensure             = file,
   $target_file_owner              = $::icinga2::config_owner,

--- a/manifests/object/opentsdbwriter.pp
+++ b/manifests/object/opentsdbwriter.pp
@@ -14,7 +14,7 @@ define icinga2::object::opentsdbwriter (
   $port       = 4242,
   # Put the object files this defined type generates in features-available
   # since the Graphite writer feature is one that has to be explicitly enabled.
-  $target_dir = '/etc/icinga2/features-available',
+  $target_dir = "${::icinga2::config_dir}/features-available",
   $file_name  = "${name}.conf",
 ) {
   # Do some validation

--- a/manifests/object/perfdatawriter.pp
+++ b/manifests/object/perfdatawriter.pp
@@ -19,7 +19,7 @@ define icinga2::object::perfdatawriter (
   $host_format_template      = undef,
   $service_format_template   = undef,
   $rotation_interval         = undef,
-  $target_dir                = '/etc/icinga2/objects/perfdatawriters',
+  $target_dir                = "${::icinga2::config_dir}/objects/perfdatawriters",
   $target_file_name          = "${name}.conf",
   $target_file_ensure        = file,
   $target_file_owner         = $::icinga2::config_owner,

--- a/manifests/object/scheduleddowntime.pp
+++ b/manifests/object/scheduleddowntime.pp
@@ -18,7 +18,7 @@ define icinga2::object::scheduleddowntime (
   $fixed                        = true,
   $duration                     = undef,
   $ranges                       = {},
-  $target_dir                   = '/etc/icinga2/objects/scheduleddowntimes',
+  $target_dir                   = "${::icinga2::config_dir}/objects/scheduleddowntimes",
   $target_file_name             = "${name}.conf",
   $target_file_ensure           = file,
   $target_file_owner            = $::icinga2::config_owner,

--- a/manifests/object/service.pp
+++ b/manifests/object/service.pp
@@ -37,7 +37,7 @@ define icinga2::object::service (
   $action_url              = undef,
   $icon_image              = undef,
   $icon_image_alt          = undef,
-  $target_dir              = '/etc/icinga2/objects/services',
+  $target_dir              = "${::icinga2::config_dir}/objects/services",
   $target_file_name        = "${name}.conf",
   $target_file_ensure      = file,
   $target_file_owner       = $::icinga2::config_owner,

--- a/manifests/object/servicegroup.pp
+++ b/manifests/object/servicegroup.pp
@@ -14,7 +14,7 @@ define icinga2::object::servicegroup (
   $display_name             = $name,
   $templates                = [],
   $groups                   = [],
-  $target_dir               = '/etc/icinga2/objects/servicegroups',
+  $target_dir               = "${::icinga2::config_dir}/objects/servicegroups",
   $target_file_name         = "${name}.conf",
   $target_file_ensure       = file,
   $target_file_owner        = $::icinga2::config_owner,

--- a/manifests/object/statusdatawriter.pp
+++ b/manifests/object/statusdatawriter.pp
@@ -14,7 +14,7 @@ define icinga2::object::statusdatawriter (
   $status_path                 = undef,
   $objects_path                = undef,
   $update_interval             = undef,
-  $target_dir                  = '/etc/icinga2/objects/statusdatawriters',
+  $target_dir                  = "${::icinga2::config_dir}/objects/statusdatawriters",
   $target_file_name            = "${name}.conf",
   $target_file_ensure          = file,
   $target_file_owner           = $::icinga2::config_owner,

--- a/manifests/object/timeperiod.pp
+++ b/manifests/object/timeperiod.pp
@@ -15,7 +15,7 @@ define icinga2::object::timeperiod (
   $timeperiod_display_name       = undef,
   $methods                       = undef,
   $ranges                        = {},
-  $target_dir                    = '/etc/icinga2/objects/timeperiods',
+  $target_dir                    = "${::icinga2::config_dir}/objects/timeperiods",
   $target_file_name              = "${name}.conf",
   $target_file_ensure            = file,
   $target_file_owner             = $::icinga2::config_owner,

--- a/manifests/object/user.pp
+++ b/manifests/object/user.pp
@@ -22,7 +22,7 @@ define icinga2::object::user (
   $period                  = undef,
   $types                   = [],
   $states                  = [],
-  $target_dir              = '/etc/icinga2/objects/users',
+  $target_dir              = "${::icinga2::config_dir}/objects/users",
   $target_file_name        = "${name}.conf",
   $target_file_ensure      = file,
   $target_file_owner       = $::icinga2::config_owner,

--- a/manifests/object/usergroup.pp
+++ b/manifests/object/usergroup.pp
@@ -14,7 +14,7 @@ define icinga2::object::usergroup (
   $display_name            = $name,
   $templates               = [],
   $groups                  = [],
-  $target_dir              = '/etc/icinga2/objects/usergroups',
+  $target_dir              = "${::icinga2::config_dir}/objects/usergroups",
   $target_file_name        = "${name}.conf",
   $target_file_ensure      = file,
   $target_file_owner       = $::icinga2::config_owner,

--- a/manifests/object/zone.pp
+++ b/manifests/object/zone.pp
@@ -12,7 +12,7 @@ define icinga2::object::zone(
   $endpoints  = undef,
   $global     = false,
   $parent     = undef,
-  $target_dir = '/etc/icinga2/objects/zones',
+  $target_dir = "${::icinga2::config_dir}/objects/zones",
   $file_name  = "${name}.conf",
 ) {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,10 +33,6 @@ class icinga2::params {
   $db_user = 'icinga2'
   $db_pass = 'password'
 
-  # the schema is currently not OS specific
-  $db_schema_mysql = '/usr/share/icinga2-ido-mysql/schema/mysql.sql'
-  $db_schema_pgsql = '/usr/share/icinga2-ido-pgsql/schema/pgsql.sql'
-
   $pid_file = '/run/icinga2/icinga2.pid'
 
   $restart_cmd = undef
@@ -118,4 +114,26 @@ class icinga2::params {
     #Fail if we're on any other OS:
     default: { fail("${::operatingsystem} is not supported!") }
   }
+
+
+  unless $config_dir {
+    $config_dir = '/etc/icinga2'
+  }
+
+  unless $sbin_dir {
+    $sbin_dir = '/usr/sbin'
+  }
+
+  unless $share_dir {
+    $share_dir = '/usr/share'
+  }
+
+  unless $var_dir {
+    $var_dir = '/var'
+  }
+
+  # the schema is now using a set parameter for the os or the default.
+  $db_schema_mysql = "${share_dir}/icinga2-ido-mysql/schema/mysql.sql"
+  $db_schema_pgsql = "${share_dir}/icinga2-ido-pgsql/schema/pgsql.sql"
+
 }

--- a/manifests/pki/icinga.pp
+++ b/manifests/pki/icinga.pp
@@ -22,7 +22,7 @@ class icinga2::pki::icinga (
 
   $ticket_id = icinga2_ticket_id($::fqdn, $ticket_salt)
 
-  $pki_dir = '/etc/icinga2/pki'
+  $pki_dir = "${::icinga2::config_dir}/pki"
   $ca = "${pki_dir}/ca.crt"
   $key = "${pki_dir}/${hostname}.key"
   $cert = "${pki_dir}/${hostname}.crt"

--- a/manifests/pki/puppet.pp
+++ b/manifests/pki/puppet.pp
@@ -3,13 +3,13 @@
 # Provide PKI certificates for Icinga2 from the Puppet agent.
 #
 class icinga2::pki::puppet(
-  $ca_path     = '/etc/icinga2/pki/ca.crt',
+  $ca_path     = "${::icinga2::config_dir}/pki/ca.crt",
   $ca_source   = "${::settings::ssldir}/certs/ca.pem",
-  $cert_path   = "/etc/icinga2/pki/${::fqdn}.crt",
+  $cert_path   = "${::icinga2::config_dir}/pki/${::fqdn}.crt",
   $cert_source = "${::settings::ssldir}/certs/${::fqdn}.pem",
-  $key_path    = "/etc/icinga2/pki/${::fqdn}.key",
+  $key_path    = "${::icinga2::config_dir}/pki/${::fqdn}.key",
   $key_source  = "${::settings::ssldir}/private_keys/${::fqdn}.pem",
-  $crl_path    = '/etc/icinga2/pki/crl.pem',
+  $crl_path    = "${::icinga2::config_dir}/pki/crl.pem",
   $crl_source  = "${::settings::ssldir}/crl.pem",
 ) {
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,7 +3,7 @@
 # This class manages the Icinga 2 daemon.
 #
 class icinga2::service {
-  $config_stamp = '/var/lib/icinga2/.puppet-config-stamp'
+  $config_stamp = "${::icinga2::var_dir}/lib/icinga2/.puppet-config-stamp"
 
   Exec {
     path => $::path,

--- a/spec/classes/icinga2_feature_mainlog_spec.rb
+++ b/spec/classes/icinga2_feature_mainlog_spec.rb
@@ -39,4 +39,19 @@ describe 'icinga2::feature::mainlog' do
     })}
   end
 
+  context "on #{default} with var_dir parameters" do
+    let :pre_condition do
+      "class { 'icinga2':
+        default_features => false,
+        var_dir          => '/var/opt',
+      }"
+    end
+
+    it { should contain_class('icinga2::feature::mainlog') }
+    it { should contain_icinga2__feature('mainlog') }
+    it { should contain_file('icinga2 feature mainlog').with({
+      :content => /severity = "information"\n\s+path = "\/var\/opt\/log\/icinga2\/icinga2\.log"/,
+    })}
+  end
+
 end

--- a/spec/defines/icinga2_feature_spec.rb
+++ b/spec/defines/icinga2_feature_spec.rb
@@ -26,7 +26,7 @@ describe 'icinga2::feature' do
     it { should contain_file('icinga2 feature checker enabled').with({
       :ensure => 'link',
       :path   => '/etc/icinga2/features-enabled/checker.conf',
-      :target => '../features-available/checker.conf',
+      :target => '/etc/icinga2/features-available/checker.conf',
     })}
     it { is_expected.to contain_file("icinga2 feature checker").that_notifies('Class[icinga2::service]') }
   end
@@ -57,5 +57,59 @@ describe 'icinga2::feature' do
     it { is_expected.not_to contain_file("icinga2 feature checker").that_notifies('Class[icinga2::service]') }
   end
 
+  context "on default #{default} with config_dir parameters" do
+    let :facts do
+      IcingaPuppet.variants[default]
+    end
+    let :pre_condition do
+      "class { 'icinga2':
+        default_features => false,
+        config_dir => '/tmp',
+      }"
+    end
+
+    let(:title) { 'checker' }
+
+    it { should contain_icinga2__feature('checker') }
+    it { should contain_file('icinga2 feature checker').with({
+      :ensure => 'file',
+      :path => '/tmp/features-available/checker.conf',
+      :content => /CheckerComponent/,
+    })}
+    it { should contain_file('icinga2 feature checker enabled').with({
+      :ensure => 'link',
+      :path   => '/tmp/features-enabled/checker.conf',
+      :target => '/tmp/features-available/checker.conf',
+    })}
+    it { is_expected.to contain_file("icinga2 feature checker").that_notifies('Class[icinga2::service]') }
+  end
+
+  context "on default #{default} with var_dir and config_dir parameters" do
+    let :facts do
+      IcingaPuppet.variants[default]
+    end
+    let :pre_condition do
+      "class { 'icinga2':
+        default_features => false,
+        config_dir => '/tmp/config',
+        var_dir    => '/tmp/var',
+      }"
+    end
+
+    let(:title) { 'checker' }
+
+    it { should contain_icinga2__feature('checker') }
+    it { should contain_file('icinga2 feature checker').with({
+      :ensure => 'file',
+      :path => '/tmp/config/features-available/checker.conf',
+      :content => /CheckerComponent/,
+    })}
+    it { should contain_file('icinga2 feature checker enabled').with({
+      :ensure => 'link',
+      :path   => '/tmp/config/features-enabled/checker.conf',
+      :target => '/tmp/config/features-available/checker.conf',
+    })}
+    it { is_expected.to contain_file("icinga2 feature checker").that_notifies('Class[icinga2::service]') }
+  end
 
 end


### PR DESCRIPTION
Prefix options for etc, var and share, alternatively a generic one for all called dirprefix that is used unless the more specific is used. 
