### PR TITLE
Use correct alignment

### DIFF
--- a/templates/object/apply_service.conf.erb
+++ b/templates/object/apply_service.conf.erb
@@ -101,7 +101,7 @@ apply Service "<%= @object_servicename %>" <%= @apply %> {
   <%- end -%>
   <%- if @custom_append && Array(@custom_append).size > 0 -%>
     <%- Array(@custom_append).each do |line| -%>
-    <%= line %>
+  <%= line %>
     <%- end -%>
   <%- end -%>
 }


### PR DESCRIPTION
Without this change, the alignment of the rendered template is incorrect when the user specifies a custom_append.
