### PR TITLE
fix documentation for install_mailutils

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,12 +203,12 @@ class { 'icinga2':
 
 **`mail` binaries**
 
-If you would like to install packages to make a `mail` command binary available so that Icinga 2 can send out email notifications, set the `install_mail_utils_package` parameter to **true**:
+Packages that are needed so that Icinga 2 can send out email notifications, are automatically installed. If you would like to prevent this, set the `install_mailutils` parameter to **false**:
 
 <pre>
   class { 'icinga2':
     ...
-    install_mail_utils_package => true,
+    install_mailutils => false,
     ...
   }
 </pre>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,9 +21,6 @@ class icinga2::params {
   #Whether to install the plugin packages when the icinga2 class is applied:
   $install_nagios_plugins = true
 
-  #whether to install packages that provide the 'mail' binary
-  $install_mail_utils_package = false
-
   $config_template = 'icinga2/icinga2.conf.erb'
   $manage_service = true
 


### PR DESCRIPTION
The documentation for the parameter to install `mail` packages was wrong. It also wasn't clear if the default is true or not. 
