### PR TITLE
Add custom_prepend and custom_append parameter to object/host.pp and

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,6 +787,16 @@ Notes on specific parameters:
 
 * `groups`: must be specified as a [Puppet array](https://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#arrays), even if there's only one element
 * `vars`: must be specified as a [Puppet hash](https://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#hashes), with the Icinga 2 variable as the **key** and the variable's value as the **value**
+* `custom_prepend` and `custom_append`: must be specified as [Puppet arrays](https://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#arrays), even if there's only one element. This allows to define free form text which will be inserted either in the beginning, or end of the hosts definition, i.e.
+
+<pre>
+    custom_append => [
+      'vars += { disks["disk"] = {} }',
+    ]
+</pre>
+
+will add the literal line 'vars += { disks["disk"] = {} }' to the host definition. This helps overcoming limitations about quoting especially in the `vars` hash.
+This also allows to add comments to the hosts file.
 
 **Note:** The `ipv6_address` parameter is set to **undef** by default. This is because `facter` can return either IPv4 or IPv6 addresses for the `ipaddress_ethX` facts. The default value for the `ipv6_address` parameter is set to **undef** and not `ipaddress_eth0` so that an IPv4 address isn't unintentionally set as the value for `address6` in the rendered host object definition.
 

--- a/manifests/object/host.pp
+++ b/manifests/object/host.pp
@@ -47,6 +47,8 @@ define icinga2::object::host (
   $refresh_icinga2_service = true,
   $zone                    = undef,
   $command_endpoint        = undef,
+  $custom_prepend          = [],
+  $custom_append           = [],
 ) {
 
   validate_string($object_hostname)
@@ -64,6 +66,8 @@ define icinga2::object::host (
   validate_bool($refresh_icinga2_service)
   validate_string($zone)
   validate_string($command_endpoint)
+  validate_array($custom_prepend)
+  validate_array($custom_append)
 
   #If the refresh_icinga2_service parameter is set to true...
   if $refresh_icinga2_service == true {

--- a/spec/defines/icinga2__object/host_spec.rb
+++ b/spec/defines/icinga2__object/host_spec.rb
@@ -165,4 +165,67 @@ describe 'icinga2::object::host' do
 
   end
 
+    context "on #{default} with custom_prepend parameter" do
+      let :facts do
+        IcingaPuppet.variants[default]
+      end
+      let :params do
+        {
+            :display_name => 'testhost',
+            :custom_prepend => [
+                'vars += { disks["disk"] = {} }',
+                '# this is just a comment',
+              ]
+        }
+      end
+      let :pre_condition do
+        "include 'icinga2'"
+      end
+
+      let(:title) { 'testhost' }
+
+      object_file = '/etc/icinga2/objects/hosts/testhost.conf'
+      it { should contain_icinga2__object__host('testhost') }
+      it { should contain_file(object_file).with({
+            :ensure => 'file',
+            :path => '/etc/icinga2/objects/hosts/testhost.conf',
+            :content => /object Host "testhost"/,
+          }) }
+      it { should contain_file(object_file).with_content(/^\s*import "generic-host"$/) }
+      it { should contain_file(object_file).with_content(/^\s*display_name = "testhost"$/) }
+      it { should contain_file(object_file).with_content(/^\s*vars \+= { disks\["disk"\] = {} }/) }
+      it { should contain_file(object_file).with_content(/^\s*# this is just a comment/) }
+    end
+    context "on #{default} with custom_append parameter" do
+      let :facts do
+        IcingaPuppet.variants[default]
+      end
+      let :params do
+        {
+            :display_name => 'testhost',
+            :custom_append => [
+                'vars += { disks["disk"] = {} }',
+                '# this is just a comment',
+              ]
+        }
+      end
+      let :pre_condition do
+        "include 'icinga2'"
+      end
+
+      let(:title) { 'testhost' }
+
+      object_file = '/etc/icinga2/objects/hosts/testhost.conf'
+      it { should contain_icinga2__object__host('testhost') }
+      it { should contain_file(object_file).with({
+            :ensure => 'file',
+            :path => '/etc/icinga2/objects/hosts/testhost.conf',
+            :content => /object Host "testhost"/,
+          }) }
+      it { should contain_file(object_file).with_content(/^\s*import "generic-host"$/) }
+      it { should contain_file(object_file).with_content(/^\s*display_name = "testhost"$/) }
+      it { should contain_file(object_file).with_content(/^\s*vars \+= { disks\["disk"\] = {} }/) }
+      it { should contain_file(object_file).with_content(/^\s*# this is just a comment/) }
+    end
+
 end

--- a/templates/object/host.conf.erb
+++ b/templates/object/host.conf.erb
@@ -16,6 +16,11 @@
   import "<%= t -%>"
   <%- end -%>
   <%- end -%>
+  <%- if @custom_prepend && Array(@custom_prepend).size > 0 -%>
+    <%- Array(@custom_prepend).each do |line| -%>
+    <%= line %>
+    <%- end -%>
+  <%- end -%>
   <%- if @display_name -%>
   display_name = "<%= @display_name -%>"
   <%- end -%>
@@ -95,5 +100,10 @@
   <%- end -%>
   <%- if @command_endpoint -%>
   command_endpoint = "<%= @command_endpoint -%>"
+  <%- end -%>
+  <%- if @custom_append && Array(@custom_append).size > 0 -%>
+    <%- Array(@custom_append).each do |line| -%>
+  <%= line %>
+    <%- end -%>
   <%- end -%>
 }


### PR DESCRIPTION
the accompanying template. Idea taken from the apply_service
class/template.

This allows me to get around the limitation I faced with regard to apply_service
and the disks, see my comment here:
https://dev.icinga.org/issues/10804
