### PR TITLE
Test 'vars' and 'env' params for checkcommands

### DIFF
--- a/spec/defines/icinga2__object/checkcommand_spec.rb
+++ b/spec/defines/icinga2__object/checkcommand_spec.rb
@@ -78,4 +78,41 @@ describe 'icinga2::object::checkcommand' do
 
   end
 
+  context 'when the vars hash is set' do
+    let(:title) { 'testcheckcommand' }
+
+    let(:params) do
+      {
+        :command => ['testcommand1'],
+        :vars => {
+          'magic_var1' => 'value1',
+          'magic_var2' => 'value2',
+        }
+      }
+    end
+
+    object_file = '/etc/icinga2/objects/checkcommands/testcheckcommand.conf'
+    it { should contain_icinga2__object__checkcommand('testcheckcommand') }
+    it { should contain_file(object_file).with_content(/^\s*vars.magic_var1 = value1$/) }
+    it { should contain_file(object_file).with_content(/^\s*vars.magic_var2 = value2$/) }
+  end
+
+  context 'when the env hash is set' do
+    let(:title) { 'testcheckcommand' }
+
+    let(:params) do
+      {
+        :command => ['testcommand1'],
+        :env => {
+          'SOMETHINGGOOD1' => 'somevalue1',
+          'SOMETHINGGOOD2' => 'somevalue2',
+        }
+      }
+    end
+
+    object_file = '/etc/icinga2/objects/checkcommands/testcheckcommand.conf'
+    it { should contain_icinga2__object__checkcommand('testcheckcommand') }
+    it { should contain_file(object_file).with_content(/^\s*env \+= {\n\s*"SOMETHINGGOOD1" = "somevalue1"\n\s*"SOMETHINGGOOD2" = "somevalue2"\n\s*}$/) }
+  end
+
 end

--- a/templates/object/checkcommand.conf.erb
+++ b/templates/object/checkcommand.conf.erb
@@ -22,18 +22,18 @@ object CheckCommand "<%= @object_checkcommandname %>" {
 
   arguments = <%= scope.function_icinga2_config_value([@arguments]) %>
   <%- end -%>
-  <%- if @vars.any? -%>
 
+  <%- if @vars.any? -%>
   <%- @vars.each do |key, val| -%>
   vars.<%= key -%> = <%= val %>
   <%- end -%>
   <%- end -%>
-  <%- if @timeout -%>
 
+  <%- if @timeout -%>
   timeout = <%= @timeout %>
   <%- end -%>
-  <%- if @env.any? -%>
 
+  <%- if @env.any? -%>
   env += <%= scope.function_icinga2_config_value([@env]) %>
   <%- end -%>
 }


### PR DESCRIPTION
This work simply adds tests to the existing functionality for both the
'vars' hash and the 'env' hash.
