### PR TITLE
fix puppet lint config

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,4 +1,4 @@
 --fail-on-warnings
 --relative
---no-80chars
+--no-140chars-check
 --no-class_inherits_from_params_class-check


### PR DESCRIPTION
no-80chars option is no longer supported
use no-140chars-check option instead
