### PR TITLE
Add support for Amazon Linux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,7 +44,7 @@ class icinga2::params {
   ##################
   # Icinga 2 parameters by OS/release
   case $::operatingsystem {
-    'CentOS', 'RedHat', 'Scientific', 'OracleLinux': {
+    'CentOS', 'RedHat', 'Scientific', 'OracleLinux', 'Amazon': {
 
       #Packages for Nagios plugins:
       $plugin_packages = [

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -12,7 +12,13 @@ class icinga2::repo {
       Class['icinga2::repo::apt'] -> Class['icinga2::install']
     }
     'RedHat': {
-      include icinga2::repo::yum
+      if $::operatingsystem == 'Amazon' {
+        class { 'icinga2::repo::yum':
+          baseurl => 'http://packages.icinga.org/epel/6/release/',
+        }
+      } else {
+        include icinga2::repo::yum
+      }
       Class['icinga2::repo::yum'] -> Class['icinga2::install']
     }
     default: {


### PR DESCRIPTION
- Add support for Amazon Linux
- Use EPEL 6 Packages because Amazon Linux is based on RHEL 6
- Tested on a legacy system of my company with Amazon Linux 2015.03
