### PR TITLE
Update apply_notification objects.

### DIFF
--- a/manifests/object/apply_notification_to_host.pp
+++ b/manifests/object/apply_notification_to_host.pp
@@ -38,8 +38,18 @@ define icinga2::object::apply_notification_to_host (
   validate_array($templates)
   validate_string($command)
   validate_hash($vars)
-  validate_array($users)
-  validate_array($user_groups)
+  if ! is_string($users) {
+    validate_array($users)
+  }
+  if ! is_array($users) {
+    validate_string($users)
+  }
+  if ! is_string($user_groups) {
+    validate_array($user_groups)
+  }
+  if ! is_array($user_groups) {
+    validate_string($user_groups)
+  }
   validate_hash($times)
   if $interval {
     validate_string($interval)

--- a/manifests/object/apply_notification_to_service.pp
+++ b/manifests/object/apply_notification_to_service.pp
@@ -40,8 +40,18 @@ define icinga2::object::apply_notification_to_service (
   validate_array($templates)
   validate_string($command)
   validate_hash($vars)
-  validate_array($users)
-  validate_array($user_groups)
+  if ! is_string($users) {
+    validate_array($users)
+  }
+  if ! is_array($users) {
+    validate_string($users)
+  }
+  if ! is_string($user_groups) {
+    validate_array($user_groups)
+  }
+  if ! is_array($user_groups) {
+    validate_string($user_groups)
+  }
   validate_hash($times)
   if $interval {
     validate_string($interval)

--- a/spec/defines/icinga2__object/apply_notification_to_host_spec.rb
+++ b/spec/defines/icinga2__object/apply_notification_to_host_spec.rb
@@ -18,6 +18,34 @@ describe 'icinga2::object::apply_notification_to_host' do
     'include ::icinga2'
   end
 
+  context 'with parameter users and user_groups = array' do
+    let(:params) do
+      {
+        :users => [ 'user1', 'user2' ],
+        :user_groups => [ 'group1', 'group2' ]
+      }
+    end
+
+    object_file = '/etc/icinga2/objects/applys/spectest.conf'
+    it { should contain_icinga2__object__apply_notification_to_host('spectest') }
+    it { should contain_file(object_file).with_content(/^\s*users = \[ "user1", "user2" \]$/) }
+    it { should contain_file(object_file).with_content(/^\s*user_groups = \[ "group1", "group2" \]$/) }
+  end
+
+  context 'with parameter users and user_groups = string' do
+    let(:params) do
+      {
+        :users => 'vars.users',
+        :user_groups => 'vars.groups',
+      }
+    end
+
+    object_file = '/etc/icinga2/objects/applys/spectest.conf'
+    it { should contain_icinga2__object__apply_notification_to_host('spectest') }
+    it { should contain_file(object_file).with_content(/^\s*users = vars.users$/) }
+    it { should contain_file(object_file).with_content(/^\s*user_groups = vars.groups$/) }
+  end
+
   context 'with basic values' do
     it { should contain_icinga2__object__apply_notification_to_host('spectest') }
 

--- a/spec/defines/icinga2__object/apply_notification_to_service_spec.rb
+++ b/spec/defines/icinga2__object/apply_notification_to_service_spec.rb
@@ -24,4 +24,38 @@ describe 'icinga2::object::apply_notification_to_service' do
     pending
   end
 
+  context 'with parameter users and user_groups = array' do
+    let(:params) do
+      {
+        :users => [ 'user1', 'user2' ],
+        :user_groups => [ 'group1', 'group2' ]
+      }
+    end
+
+    object_file = '/etc/icinga2/objects/applys/spectest.conf'
+    it { should contain_icinga2__object__apply_notification_to_service('spectest') }
+    it { should contain_file(object_file).with_content(/^\s*users = \[ "user1", "user2" \]$/) }
+    it { should contain_file(object_file).with_content(/^\s*user_groups = \[ "group1", "group2" \]$/) }
+  end
+
+  context 'with parameter users and user_groups = string' do
+    let(:params) do
+      {
+        :users => 'vars.users',
+        :user_groups => 'vars.groups',
+      }
+    end
+
+    object_file = '/etc/icinga2/objects/applys/spectest.conf'
+    it { should contain_icinga2__object__apply_notification_to_service('spectest') }
+    it { should contain_file(object_file).with_content(/^\s*users = vars.users$/) }
+    it { should contain_file(object_file).with_content(/^\s*user_groups = vars.groups$/) }
+  end
+
+  context 'with basic values' do
+    it { should contain_icinga2__object__apply_notification_to_service('spectest') }
+
+    pending
+  end
+
 end

--- a/templates/object/apply_notification_to_host.conf.erb
+++ b/templates/object/apply_notification_to_host.conf.erb
@@ -27,10 +27,20 @@ apply Notification "<%= @object_notificationname %>" to Host {
   vars += <%= scope.function_icinga2_config_value([@vars]) %>
   <%- end -%>
   <%- if @users.empty? !=true -%>
+  <%- if @users.is_a?(Array) -%>
   users = [ <% @users.each_with_index do |usr, i| %>"<%= usr -%>"<%= ', ' if i < (@users.size - 1) %><% end %> ]
   <%- end -%>
+  <%- if @users.is_a?(String) -%>
+  users = <%= @users %>
+  <%- end -%>
+  <%- end -%>
   <%- if @user_groups.empty? !=true -%>
+  <%- if @user_groups.is_a?(Array) -%>
   user_groups = [ <% @user_groups.each_with_index do |u_grp, i| %>"<%= u_grp -%>"<%= ', ' if i < (@user_groups.size - 1) %><% end %> ]
+  <%- end -%>
+  <%- if @users.is_a?(String) -%>
+  user_groups = <%= @user_groups %>
+  <%- end -%>
   <%- end -%>
   <%- if @times.empty? != true -%>
   times = {

--- a/templates/object/apply_notification_to_service.conf.erb
+++ b/templates/object/apply_notification_to_service.conf.erb
@@ -30,10 +30,20 @@ apply Notification "<%= @object_notificationname %>" to Service {
   vars += <%= scope.function_icinga2_config_value([@vars]) %>
   <%- end -%>
   <%- if @users.empty? !=true -%>
+  <%- if @users.is_a?(Array) -%>
   users = [ <% @users.each_with_index do |usr, i| %>"<%= usr -%>"<%= ', ' if i < (@users.size - 1) %><% end %> ]
   <%- end -%>
+  <%- if @users.is_a?(String) -%>
+  users = <%= @users %>
+  <%- end -%>
+  <%- end -%>
   <%- if @user_groups.empty? !=true -%>
+  <%- if @user_groups.is_a?(Array) -%>
   user_groups = [ <% @user_groups.each_with_index do |u_grp, i| %>"<%= u_grp -%>"<%= ', ' if i < (@user_groups.size - 1) %><% end %> ]
+  <%- end -%>
+  <%- if @users.is_a?(String) -%>
+  user_groups = <%= @user_groups %>
+  <%- end -%>
   <%- end -%>
   <%- if @times.empty? != true -%>
   times = {


### PR DESCRIPTION
This includes the apply_notification_to_service and
apply_notification_to_host object.

Make it possible to set a string for "users" and "user_groups". This is
necessary if you want to use variables as values, e.g.

users = host.vars.notification.mail.users
user_groups = host.vars.notification.mail.groups

Update the rspec tests.
