### PR TITLE
Print values unquoted in apply dependency template.

### DIFF
--- a/templates/object/apply_dependency.conf.erb
+++ b/templates/object/apply_dependency.conf.erb
@@ -11,18 +11,18 @@
  */
 
 apply Dependency "<%= @object_name %>" to "<%= @object_type %>"{
-  <%#- If any of the @ parameters are undefined, don't print anything for them: -%>
+  <%-# If any of the @ parameters are undefined, don't print anything for them: -%>
   <%- if @parent_host_name -%>
-  parent_host_name =  "<%= @parent_host_name -%>"
+  parent_host_name = <%= @parent_host_name %>
   <%- end -%>
   <%- if @child_host_name -%>
-  child_host_name = "<%= @child_host_name -%>"
+  child_host_name = <%= @child_host_name %>
   <%- end -%>
   <%- if @parent_service_name -%>
-  parent_service_name = "<%= @parent_service_name -%>"
+  parent_service_name = <%= @parent_service_name %>
   <%- end -%>
   <%- if @child_service_name -%>
-  child_service_name = "<%= @child_service_name -%>"
+  child_service_name = <%= @child_service_name %>
   <%- end -%>
   <%- if @disable_checks -%>
   disable_checks = <%= @disable_checks %>
@@ -31,7 +31,7 @@ apply Dependency "<%= @object_name %>" to "<%= @object_type %>"{
   disable_notifications = <%= @disable_notifications %>
   <%- end -%>
   <%- if @period -%>
-  period = "<%= @period -%>"
+  period = <%= @period %>
   <%- end -%>
   <%- if @states.length != 0 -%>
   states = [ <%- @states.each do |state| -%> <%= state %>, <%- end -%>]


### PR DESCRIPTION
Remove quotes from values in template. This makes it possible to use variables
as value, e.g.

  icinga2::object::apply_dependency { 'vm-host-to-parent-master':
    parent_host_name => 'host.vars.vm_parent',
    ...
  }

To use a string as value, set quotes in the config, e.g.

  icinga2::object::apply_dependency { 'vm-host-to-internet':
    parent_host_name => '"core-router"',
    ...
  }
